### PR TITLE
Support for setting ConsistencyLevel in CassandraCqlClusterFactoryBean

### DIFF
--- a/spring-cql/src/main/java/org/springframework/cassandra/config/CassandraCqlClusterFactoryBean.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/config/CassandraCqlClusterFactoryBean.java
@@ -43,6 +43,7 @@ import com.datastax.driver.core.Host;
 import com.datastax.driver.core.LatencyTracker;
 import com.datastax.driver.core.PoolingOptions;
 import com.datastax.driver.core.ProtocolOptions.Compression;
+import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.SSLOptions;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SocketOptions;
@@ -79,6 +80,7 @@ public class CassandraCqlClusterFactoryBean implements FactoryBean<Cluster>, Ini
 	private CompressionType compressionType;
 	private PoolingOptions poolingOptions;
 	private SocketOptions socketOptions;
+	private QueryOptions queryOptions;
 	private AuthProvider authProvider;
 	private String username;
 	private String password;
@@ -140,6 +142,10 @@ public class CassandraCqlClusterFactoryBean implements FactoryBean<Cluster>, Ini
 
 		if (socketOptions != null) {
 			builder.withSocketOptions(socketOptions);
+		}
+
+		if (queryOptions != null) {
+			builder.withQueryOptions(queryOptions);
 		}
 
 		if (authProvider != null) {
@@ -288,6 +294,10 @@ public class CassandraCqlClusterFactoryBean implements FactoryBean<Cluster>, Ini
 
 	public void setSocketOptions(SocketOptions socketOptions) {
 		this.socketOptions = socketOptions;
+	}
+
+	public void setQueryOptions(QueryOptions queryOptions) {
+		this.queryOptions = queryOptions;
 	}
 
 	public void setAuthProvider(AuthProvider authProvider) {

--- a/spring-cql/src/main/java/org/springframework/cassandra/config/xml/CassandraCqlClusterParser.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/config/xml/CassandraCqlClusterParser.java
@@ -102,6 +102,7 @@ public class CassandraCqlClusterParser extends AbstractBeanDefinitionParser {
 		addOptionalPropertyValue(builder, "sslEnabled", element, "ssl-enabled", null);
 
 		addOptionalPropertyReference(builder, "authProvider", element, "auth-info-provider-ref", null);
+		addOptionalPropertyReference(builder, "queryOptions", element, "query-options-ref", null);
 		addOptionalPropertyReference(builder, "loadBalancingPolicy", element, "load-balancing-policy-ref", null);
 		addOptionalPropertyReference(builder, "reconnectionPolicy", element, "reconnection-policy-ref", null);
 		addOptionalPropertyReference(builder, "retryPolicy", element, "retry-policy-ref", null);

--- a/spring-cql/src/main/java/org/springframework/cassandra/core/ConsistencyLevel.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/core/ConsistencyLevel.java
@@ -22,6 +22,19 @@ package org.springframework.cassandra.core;
  */
 public enum ConsistencyLevel {
 
-	ANY, ONE, TWO, THREE, QUOROM, LOCAL_QUOROM, EACH_QUOROM, ALL, LOCAL_ONE, SERIAL, LOCAL_SERIAL
+	ANY,
+	ONE,
+	TWO,
+	THREE,
+	@Deprecated QUOROM,
+	QUORUM,
+	@Deprecated LOCAL_QUOROM,
+	LOCAL_QUORUM,
+	@Deprecated EACH_QUOROM,
+	EACH_QUORUM,
+	ALL,
+	LOCAL_ONE,
+	SERIAL,
+	LOCAL_SERIAL
 
 }

--- a/spring-cql/src/main/java/org/springframework/cassandra/core/ConsistencyLevelResolver.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/core/ConsistencyLevelResolver.java
@@ -54,12 +54,15 @@ public final class ConsistencyLevelResolver {
 				resolvedLevel = com.datastax.driver.core.ConsistencyLevel.ANY;
 				break;
 			case EACH_QUOROM:
+			case EACH_QUORUM:
 				resolvedLevel = com.datastax.driver.core.ConsistencyLevel.EACH_QUORUM;
 				break;
 			case LOCAL_QUOROM:
+			case LOCAL_QUORUM:
 				resolvedLevel = com.datastax.driver.core.ConsistencyLevel.LOCAL_QUORUM;
 				break;
 			case QUOROM:
+			case QUORUM:
 				resolvedLevel = com.datastax.driver.core.ConsistencyLevel.QUORUM;
 				break;
 			case THREE:

--- a/spring-cql/src/main/resources/org/springframework/cassandra/config/spring-cql-1.0.xsd
+++ b/spring-cql/src/main/resources/org/springframework/cassandra/config/spring-cql-1.0.xsd
@@ -197,6 +197,23 @@ AuthInfoProvider implementation.
 				<xsd:union memberTypes="xsd:string" />
 			</xsd:simpleType>
 		</xsd:attribute>
+		<xsd:attribute name="query-options-ref" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+QueryOptions for cluster.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="com.datastax.driver.core.QueryOptions" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+				<xsd:union memberTypes="xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
 		<xsd:attribute name="load-balancing-policy-ref" use="optional">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[

--- a/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cassandra-1.0.xsd
+++ b/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cassandra-1.0.xsd
@@ -206,6 +206,23 @@ AuthInfoProvider implementation.
 				<xsd:union memberTypes="xsd:string" />
 			</xsd:simpleType>
 		</xsd:attribute>
+		<xsd:attribute name="query-options-ref" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+QueryOptions for cluster.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="com.datastax.driver.core.QueryOptions" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+				<xsd:union memberTypes="xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
 		<xsd:attribute name="load-balancing-policy-ref" use="optional">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[


### PR DESCRIPTION
This change adds the possibility to set QueryOptions (for both reading and writing) at the cluster level.

Additionally - I've added *QUORUM values to the ConsistencyLevel  enum (since there were only *QUOROM values). I didn't remove the old values, since they may already be used.