### PR TITLE
added table discrimination functionality

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraSessionFactoryBean.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraSessionFactoryBean.java
@@ -96,7 +96,7 @@ public class CassandraSessionFactoryBean extends CassandraCqlSessionFactoryBean 
 				.getNonPrimaryKeyEntities();
 
 		for (CassandraPersistentEntity<?> entity : entities) {
-			admin.createTable(false, entity.getTableName(), entity.getType(), null); // TODO: allow spec of table options
+			admin.createTable(false, null, entity.getType(), null); // TODO: allow spec of table options
 		}
 	}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/DefaultBeanNames.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/DefaultBeanNames.java
@@ -22,4 +22,5 @@ public interface DefaultBeanNames extends DefaultCqlBeanNames {
 	public static final String DATA_TEMPLATE = "cassandraTemplate";
 	public static final String CONVERTER = "cassandraConverter";
 	public static final String CONTEXT = "cassandraMapping";
+	public static final String CONVERSION_SERVICE = "conversionService";
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/java/AbstractCassandraConfiguration.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/java/AbstractCassandraConfiguration.java
@@ -21,16 +21,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
-import org.springframework.data.cassandra.config.CassandraSessionFactoryBean;
 import org.springframework.data.cassandra.config.CassandraEntityClassScanner;
+import org.springframework.data.cassandra.config.CassandraSessionFactoryBean;
 import org.springframework.data.cassandra.config.SchemaAction;
 import org.springframework.data.cassandra.convert.CassandraConverter;
 import org.springframework.data.cassandra.convert.MappingCassandraConverter;
 import org.springframework.data.cassandra.core.CassandraAdminOperations;
 import org.springframework.data.cassandra.core.CassandraAdminTemplate;
-import org.springframework.data.cassandra.mapping.CassandraMappingContext;
-import org.springframework.data.cassandra.mapping.BasicCassandraMappingContext;
-import org.springframework.data.cassandra.mapping.Table;
+import org.springframework.data.cassandra.mapping.*;
 import org.springframework.data.mapping.context.MappingContext;
 
 /**
@@ -114,6 +112,11 @@ public abstract class AbstractCassandraConfiguration extends AbstractClusterConf
 	public ConversionService conversionService() {
         return new DefaultConversionService();
     }
+
+	@Bean
+	public DiscriminatorConverter<?> stringDiscriminatorConverter(){
+		return new StringDiscriminatorConverter();
+	}
 
     @Override
 	public void setBeanClassLoader(ClassLoader classLoader) {

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraAdminTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraAdminTemplate.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cassandra.core.SessionCallback;
 import org.springframework.cassandra.core.cql.CqlIdentifier;
 import org.springframework.cassandra.core.cql.generator.CreateTableCqlGenerator;
+import org.springframework.cassandra.core.keyspace.CreateTableSpecification;
 import org.springframework.cassandra.core.keyspace.DropTableSpecification;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.cassandra.convert.CassandraConverter;
@@ -60,12 +61,14 @@ public class CassandraAdminTemplate extends CassandraTemplate implements Cassand
 			@Override
 			public Object doInSession(Session s) throws DataAccessException {
 
-				String cql = new CreateTableCqlGenerator(getCassandraMappingContext().
-						getCreateTableSpecificationFor(entity).ifNotExists(ifNotExists)).toCql();
+				List<CreateTableSpecification> tableSpecs = getCassandraMappingContext().getCreateTableSpecificationFor(entity);
+				for (CreateTableSpecification tableSpec : tableSpecs) {
+					String cql = new CreateTableCqlGenerator(tableSpec.ifNotExists(ifNotExists)).toCql();
 
-				log.debug(cql);
+					log.debug(cql);
 
-				s.execute(cql);
+					s.execute(cql);
+				}
 				return null;
 			}
 		});

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/MultiTableCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/MultiTableCassandraTemplate.java
@@ -1,0 +1,218 @@
+package org.springframework.data.cassandra.core;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.cassandra.core.CqlTemplate;
+import org.springframework.cassandra.core.QueryOptions;
+import org.springframework.cassandra.core.WriteOptions;
+import org.springframework.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.convert.CassandraConverter;
+import org.springframework.data.cassandra.mapping.CassandraPersistentEntity;
+import org.springframework.util.Assert;
+
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.*;
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableListMultimap;
+
+/**
+ * Created by Lukasz Swiatek on 6/9/16.
+ */
+public class MultiTableCassandraTemplate extends CassandraTemplate {
+
+    public MultiTableCassandraTemplate() {
+        super();
+    }
+
+    public MultiTableCassandraTemplate(Session session) {
+        super(session);
+    }
+
+    public MultiTableCassandraTemplate(Session session, CassandraConverter converter) {
+        super(session, converter);
+    }
+
+    @Override
+    protected <T> T doInsert(T entity, WriteOptions options) {
+        Assert.notNull(entity);
+        Insert insert = createInsertQuery(getTableName(entity).toCql(), entity, options, cassandraConverter);
+        execute(insert);
+        return entity;
+    }
+
+    @Override
+    protected <T> List<T> doBatchWrite(List<T> entities, WriteOptions options, boolean insert) {
+        if (entities == null || entities.size() == 0) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("no-op due to given null or empty list");
+            }
+            return entities;
+        }
+
+
+        ImmutableListMultimap<String, T> tables = FluentIterable.from(entities).index(new Function<T, String>() {
+            @Override
+            public String apply(T input) {
+                return getTableName(input).toCql();
+            }
+        });
+
+        Batch b = QueryBuilder.batch();
+
+        for (String table : tables.keySet()) {
+            for (T entity : tables.get(table)) {
+                b.add( insert ?
+                        createInsertQuery(table, entity, options, cassandraConverter)
+                         : createUpdateQuery(table, entity, options, cassandraConverter)
+
+                );
+            }
+        }
+        CqlTemplate.addQueryOptions(b, options);
+
+        execute(b);
+
+        return entities;
+    }
+
+    @Override
+    public <T> T selectOneById(Class<T> type, Object id) {
+
+        Assert.notNull(type);
+        Assert.notNull(id);
+
+        CassandraPersistentEntity<?> entity = mappingContext.getPersistentEntity(type);
+        if (entity == null) {
+            throw new IllegalArgumentException(String.format("unknown entity class [%s]", type.getName()));
+        }
+
+        Select select = QueryBuilder.select().all().from(getTableName(type, id).toCql());
+        appendIdCriteria(select.where(), entity, id);
+
+        return selectOne(select, type);
+    }
+
+    @Override
+    public boolean exists(Class<?> type, Object id) {
+        Assert.notNull(type);
+        Assert.notNull(id);
+
+        CassandraPersistentEntity<?> entity = mappingContext.getPersistentEntity(type);
+
+        Select select = QueryBuilder.select().countAll().from(getTableName(type, id).toCql());
+        appendIdCriteria(select.where(), entity, id);
+
+        Long count = queryForObject(select, Long.class);
+
+        return count != 0;
+    }
+
+    @Override
+    public void deleteById(Class<?> type, Object id) {
+        Assert.notNull(type);
+        Assert.notNull(id);
+
+        CassandraPersistentEntity<?> entity = mappingContext.getPersistentEntity(type);
+
+        Delete delete = QueryBuilder.delete().from(getTableName(type, id).toCql());
+        appendIdCriteria(delete.where(), entity, id);
+
+        execute(delete);
+    }
+
+
+    protected <T> void doBatchDelete(List<T> entities, QueryOptions options) {
+        if (entities == null || entities.size() == 0) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("no-op due to given null or empty list");
+            }
+            return ;
+        }
+
+        ImmutableListMultimap<String, T> tables = FluentIterable.from(entities).index(new Function<T, String>() {
+            @Override
+            public String apply(T input) {
+                return getTableName(input).toCql();
+            }
+        });
+
+        Batch b = QueryBuilder.batch();
+        for (String table : tables.keySet()) {
+            for (T entity : tables.get(table)) {
+                b.add( createDeleteQuery(table, entity, options, cassandraConverter));
+            }
+        }
+        CqlTemplate.addQueryOptions(b, options);
+
+        execute(b);
+    }
+
+
+    @Override
+    public long count(Class<?> type) {
+        List<CqlIdentifier> tableNames = mappingContext.getPersistentEntity(type).getEntityDiscriminator().getTableNames();
+        long count=0;
+        for (CqlIdentifier tableName : tableNames) {
+            count+=count(tableName.toCql());
+        }
+        return count;
+    }
+
+    @Override
+    public CqlIdentifier getTableName(Class<?> type) {
+        if (mappingContext.getPersistentEntity(type).getEntityDiscriminator().isMultitable()){
+            throw new UnsupportedOperationException();
+        }
+        return super.getTableName(type);
+    }
+
+    @Override
+    public <T> List<T> selectAll(Class<T> type) {
+        List<CqlIdentifier> tableNames = mappingContext.getPersistentEntity(type).getEntityDiscriminator().getTableNames();
+        List<T> result = new ArrayList<T>();
+        for (CqlIdentifier tableName : tableNames) {
+            result.addAll(select(QueryBuilder.select().all().from(tableName.toCql()), type));
+        }
+        return result;
+    }
+
+    protected <T> void doDelete(T entity, QueryOptions options) {
+
+        Assert.notNull(entity);
+        Delete delete = createDeleteQuery(getTableName(entity).toCql(), entity, options, cassandraConverter);
+        execute(delete);
+    }
+
+    protected <T> T doUpdate(T entity, WriteOptions options) {
+
+        Assert.notNull(entity);
+        Update update = createUpdateQuery(getTableName(entity).toCql(), entity, options, cassandraConverter);
+        execute(update);
+        return entity;
+    }
+
+    @Override
+    public <T> void deleteAll(Class<T> clazz) {
+
+        if (!mappingContext.contains(clazz)) {
+            throw new IllegalArgumentException(String.format("unknown persistent entity class [%s]", clazz.getName()));
+        }
+
+        CassandraPersistentEntity<?> persistentEntity = mappingContext.getPersistentEntity(clazz);
+        for (CqlIdentifier tableName : persistentEntity.getEntityDiscriminator().getTableNames()) {
+            truncate(tableName);
+        }
+    }
+
+    private CqlIdentifier getTableName(Class<?> type, Object id) {
+        CassandraPersistentEntity<?> entity = mappingContext.getPersistentEntity(type);
+        return entity.getEntityDiscriminator().getTableNameForId(id);
+    }
+
+    private CqlIdentifier getTableName(Object type) {
+        CassandraPersistentEntity<Object> entity = (CassandraPersistentEntity<Object>) mappingContext.getPersistentEntity(type.getClass());
+        return entity.getEntityDiscriminator().getTableNameFor(type);
+    }
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/BasicCassandraPersistentEntity.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/BasicCassandraPersistentEntity.java
@@ -60,6 +60,7 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 	protected ApplicationContext context;
 	protected Boolean forceQuote;
 	protected Map<TableOption, Object> tableOptions = new HashMap<TableOption, Object>();
+	protected EntityDiscriminator<T> discriminator;
 
 	public BasicCassandraPersistentEntity(TypeInformation<T> typeInformation) {
 		this(typeInformation, null);
@@ -148,6 +149,9 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 
 		Assert.notNull(tableName);
 		this.tableName = tableName;
+		//rebuild discriminator after table name change
+		this.discriminator=null;
+		getEntityDiscriminator();
 	}
 
 	@Override
@@ -165,6 +169,26 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 	@Override
 	public Map<TableOption, Object> getTableOptions() {
 		return tableOptions;
+	}
+
+	@Override
+	public EntityDiscriminator<T> getEntityDiscriminator() {
+		if (discriminator == null) {
+			CassandraPersistentProperty idProperty = getIdProperty();
+			if (idProperty != null) {
+				CassandraPersistentEntity<?> key = getMappingContext().getPersistentEntity(idProperty.getType());
+				if (key != null) {
+					CassandraPersistentProperty persistentProperty = key.getPersistentProperty(TableDiscriminator.class);
+					if (persistentProperty != null) {
+						discriminator = new MultitableEntityDiscriminator<T>(this);
+					}
+				}
+			}
+			if (discriminator ==null){
+				discriminator= new BasicEntityDiscriminator<T>(getTableName());
+			}
+		}
+		return discriminator;
 	}
 
 	@Override

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/BasicCassandraPersistentProperty.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/BasicCassandraPersistentProperty.java
@@ -401,6 +401,11 @@ public class BasicCassandraPersistentProperty extends AnnotationBasedPersistentP
 		return this.columnComments = Collections.unmodifiableMap(determineColumnComments());
 	}
 
+	@Override
+	public boolean isDiscriminator() {
+		return getType().isAnnotationPresent(TableDiscriminator.class);
+	}
+
 	private Map<CqlIdentifier, String> determineColumnComments() {
 		Map<CqlIdentifier, String> comments = new HashMap<CqlIdentifier, String>();
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/BasicEntityDiscriminator.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/BasicEntityDiscriminator.java
@@ -1,0 +1,54 @@
+package org.springframework.data.cassandra.mapping;
+
+import java.util.List;
+
+import org.springframework.cassandra.core.cql.CqlIdentifier;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Entity discriminator for {@link CassandraPersistentEntity} defined without {@link TableDiscriminator}.
+ * It will return passed tableName.
+ */
+public class BasicEntityDiscriminator<T>  implements EntityDiscriminator<T> {
+    private CqlIdentifier tableName;
+
+    public BasicEntityDiscriminator(CqlIdentifier tableName) {
+        this.tableName = tableName;
+    }
+
+    @Override
+    public CqlIdentifier getTableNameFor(T entity) {
+        return tableName;
+    }
+
+    @Override
+    public CqlIdentifier getTableNameForId(Object id) {
+        return tableName;
+    }
+
+    @Override
+    public CqlIdentifier getTableNameForDiscriminator(Object discriminator) {
+        return tableName;
+    }
+
+    @Override
+    public void setDiscriminatorValue(T entity, Object value) {
+
+    }
+
+    @Override
+    public Object parseTableName(String tableName) {
+        return null;
+    }
+
+    @Override
+    public List<CqlIdentifier> getTableNames() {
+        return Lists.newArrayList(tableName);
+    }
+
+    @Override
+    public boolean isMultitable() {
+        return false;
+    }
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/CassandraMappingContext.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/CassandraMappingContext.java
@@ -16,6 +16,7 @@
 package org.springframework.data.cassandra.mapping;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.springframework.cassandra.core.keyspace.CreateTableSpecification;
 import org.springframework.data.mapping.context.MappingContext;
@@ -59,11 +60,11 @@ public interface CassandraMappingContext extends
 	Collection<CassandraPersistentEntity<?>> getNonPrimaryKeyEntities();
 
 	/**
-	 * Returns a {@link CreateTableSpecification} for the given entity, including all mapping information.
+	 * Returns a list of {@link CreateTableSpecification} for the given entity, including all mapping information.
 	 * 
 	 * @param The entity. May not be null.
 	 */
-	CreateTableSpecification getCreateTableSpecificationFor(CassandraPersistentEntity<?> entity);
+	List<CreateTableSpecification> getCreateTableSpecificationFor(CassandraPersistentEntity<?> entity);
 
 	/**
 	 * Returns whether this mapping context has any entities mapped to the given table.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/CassandraPersistentEntity.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/CassandraPersistentEntity.java
@@ -59,4 +59,7 @@ public interface CassandraPersistentEntity<T> extends MutablePersistentEntity<T,
 	 * Returns {@link TableOption}s and values associated with the entity
 	 */
 	Map<TableOption, Object> getTableOptions();
+
+	EntityDiscriminator<T> getEntityDiscriminator();
+
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/CassandraPersistentProperty.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/CassandraPersistentProperty.java
@@ -147,6 +147,8 @@ public interface CassandraPersistentProperty extends PersistentProperty<Cassandr
 	 */
 	Map<CqlIdentifier, String> getColumnComments();
 
+	boolean isDiscriminator();
+
 	public enum PropertyToFieldNameConverter implements Converter<CassandraPersistentProperty, String> {
 
 		INSTANCE;

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/DiscriminatorConverter.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/DiscriminatorConverter.java
@@ -1,0 +1,16 @@
+package org.springframework.data.cassandra.mapping;
+
+import java.util.List;
+
+/**
+ * Converter for fields annotated with {@link TableDiscriminator}.
+ * It allows to
+ *      * convert discriminator type to string which will be used as part of table name
+ *      * convert string extracted from table name back to discriminator object
+ *      * list all values - used if {@link TableDiscriminator} does not specify discriminator values
+ */
+public interface DiscriminatorConverter<T> {
+    List<String> getAllValues();
+    String convert(T discriminator);
+    T fromString(String tableName);
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/EntityDiscriminator.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/EntityDiscriminator.java
@@ -1,0 +1,23 @@
+package org.springframework.data.cassandra.mapping;
+
+import java.util.List;
+
+import org.springframework.cassandra.core.cql.CqlIdentifier;
+
+/**
+ * Entity discriminator provides functionality to discriminate entities by resolving table name based on entity properties.
+ */
+public interface EntityDiscriminator<T> {
+    CqlIdentifier getTableNameFor(T entity);
+
+    CqlIdentifier getTableNameForId(Object id);
+
+    CqlIdentifier getTableNameForDiscriminator(Object discriminator);
+
+    void setDiscriminatorValue(T entity, Object value);
+
+    Object parseTableName(String tableName);
+
+    List<CqlIdentifier> getTableNames();
+    boolean isMultitable();
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/EnumDiscriminatorConverter.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/EnumDiscriminatorConverter.java
@@ -1,0 +1,35 @@
+package org.springframework.data.cassandra.mapping;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by Lukasz Swiatek on 6/15/16.
+ */
+public class EnumDiscriminatorConverter<T extends Enum<T>> implements DiscriminatorConverter<T> {
+    private Class<T> enumClass;
+
+    public EnumDiscriminatorConverter(Class<T> enumClass) {
+        this.enumClass = enumClass;
+    }
+
+    @Override
+    public List<String> getAllValues() {
+        Enum[] enumConstants = enumClass.getEnumConstants();
+        List<String> allValues = new ArrayList<String>(enumConstants.length);
+        for (Enum en : enumConstants) {
+            allValues.add(en.name());
+        }
+        return allValues;
+    }
+
+    @Override
+    public String convert(T discriminator) {
+        return discriminator.name();
+    }
+
+    @Override
+    public T fromString(String tableNAme) {
+        return Enum.valueOf(enumClass, tableNAme);
+    }
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/MultitableEntityDiscriminator.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/MultitableEntityDiscriminator.java
@@ -1,0 +1,155 @@
+package org.springframework.data.cassandra.mapping;
+
+import static org.springframework.cassandra.core.cql.CqlIdentifier.cqlId;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.mapping.IdentifierAccessor;
+import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.data.mapping.model.MappingException;
+import org.springframework.util.StringUtils;
+
+/**
+ * Entity discriminator for entities with {@link TableDiscriminator}.
+ * This will allow to resolve table name template by transforming value of annotated property.
+ * If {@link TableDiscriminator} does not define list of allowed values, then for enum fields all enum names will be used.
+ * For any other type converter defined in {@link TableDiscriminator} must provide list of discriminator names.
+ */
+public class MultitableEntityDiscriminator<T> implements EntityDiscriminator<T> {
+    public static final String DISCRIMINATOR_PLACEHOLDER = "@discriminator";
+    private DiscriminatorConverter<?> discriminatorConverter;
+    private String tableNameTemplate;
+    private TableDiscriminator discriminator;
+    private List<CqlIdentifier> tableNames;
+    private CassandraPersistentEntity<T> persistentEntity;
+    private final Table table;
+
+    public MultitableEntityDiscriminator(CassandraPersistentEntity<T> persistentEntity) {
+        CassandraPersistentEntity<?> key = persistentEntity.getMappingContext().getPersistentEntity(persistentEntity.getIdProperty().getType());
+        CassandraPersistentProperty persistentProperty = key.getPersistentProperty(TableDiscriminator.class);
+        this.discriminator = persistentProperty.getField().getAnnotation(TableDiscriminator.class);
+        this.table = persistentEntity.getType().getAnnotation(Table.class);
+        this.persistentEntity = persistentEntity;
+    }
+
+    private String getTableNameTemplate() {
+        if (tableNameTemplate == null) {
+            if (table == null || !StringUtils.hasText(table.value())) {
+                tableNameTemplate = persistentEntity.getType().getSimpleName();
+            } else {
+                tableNameTemplate = table.value();
+            }
+        }
+        return tableNameTemplate;
+    }
+
+    private DiscriminatorConverter<?> getDiscriminatorConverter() {
+        if (discriminatorConverter == null) {
+            Class<?> type = getDiscriminatorProperty().getType();
+            if (type.isEnum()) {
+                this.discriminatorConverter = new EnumDiscriminatorConverter(type);
+            } else if (String.class.isAssignableFrom(type)) {
+                this.discriminatorConverter = StringDiscriminatorConverter.IT;
+            } else {
+                Class<? extends DiscriminatorConverter>[] classes = discriminator.converter();
+                if (classes.length != 1) {
+                    throw new MappingException("Exactly one discriminator converter is required when using non String/Enum discriminator type");
+                }
+                this.discriminatorConverter = persistentEntity.getApplicationContext().getBean(classes[0]);
+            }
+        }
+        return discriminatorConverter;
+    }
+
+    private PersistentPropertyAccessor getIdentifierPropertyAccessor(T object) {
+        IdentifierAccessor keyProp = persistentEntity.getIdentifierAccessor(object);
+        CassandraPersistentEntity<?> keyEntity = getPersistentPrimaryKeyEntity();
+        return keyEntity.getPropertyAccessor(keyProp.getIdentifier());
+    }
+
+    private CassandraPersistentProperty getDiscriminatorProperty() {
+        CassandraPersistentEntity<?> keyEntity = getPersistentPrimaryKeyEntity();
+        return keyEntity.getPersistentProperty(TableDiscriminator.class);
+    }
+
+    private CassandraPersistentEntity<?> getPersistentPrimaryKeyEntity() {
+        return persistentEntity.getMappingContext().getPersistentEntity(persistentEntity.getIdProperty().getType());
+    }
+
+    @Override
+    public CqlIdentifier getTableNameFor(T entity) {
+        Object identifier = persistentEntity.getIdentifierAccessor(entity).getIdentifier();
+        return getTableNameForId(identifier);
+    }
+
+    @Override
+    public CqlIdentifier getTableNameForId(Object id) {
+        CassandraPersistentEntity<?> keyEntity = persistentEntity.getMappingContext().getPersistentEntity(id.getClass());
+        CassandraPersistentProperty discProp = keyEntity.getPersistentProperty(TableDiscriminator.class);
+        Object property = keyEntity.getPropertyAccessor(id).getProperty(discProp);
+        return getTableNameForDiscriminator(property);
+    }
+
+    @Override
+    public CqlIdentifier getTableNameForDiscriminator(Object discriminator) {
+        DiscriminatorConverter<Object> converter = (DiscriminatorConverter<Object>) getDiscriminatorConverter();
+        CqlIdentifier tableName = evalTemplate(converter.convert(discriminator));
+        if (!getTableNames().contains(tableName)) {
+            throw new MappingException("Given discriminator is not in defined set");
+        }
+        return tableName;
+    }
+
+    @Override
+    public void setDiscriminatorValue(T entity, Object value) {
+        PersistentPropertyAccessor accessor = getIdentifierPropertyAccessor(entity);
+        accessor.setProperty(getDiscriminatorProperty(), value);
+    }
+
+    private CqlIdentifier evalTemplate(String disc) {
+        String result = getTableNameTemplate().replace(DISCRIMINATOR_PLACEHOLDER, disc);
+        return cqlId(result, table.forceQuote());
+    }
+
+    @Override
+    public Object parseTableName(String tableName) {
+        String pattern = getTableNameTemplate().replace(DISCRIMINATOR_PLACEHOLDER, "(\\w+?)");
+        Pattern compile = Pattern.compile(pattern, !table.forceQuote() ? Pattern.CASE_INSENSITIVE : 0);
+        Matcher matcher = compile.matcher(tableName);
+        if (matcher.find()) {
+            String group = matcher.group(1);
+            return getDiscriminatorConverter().fromString(group);
+        }
+        throw new MappingException("Could not parse table discriminator");
+    }
+
+    @Override
+    public List<CqlIdentifier> getTableNames() {
+        if (tableNames == null || tableNames.size() == 0) {
+            tableNames = new ArrayList<CqlIdentifier>();
+            List<String> allValues;
+            if (discriminator.value().length > 0) {
+                allValues = Arrays.asList(discriminator.value());
+            } else {
+                allValues = getDiscriminatorConverter().getAllValues();
+            }
+
+            for (String disc : allValues) {
+                CqlIdentifier tableName = evalTemplate(disc);
+                tableNames.add(tableName);
+            }
+        }
+        return tableNames;
+    }
+
+    @Override
+    public boolean isMultitable() {
+        return true;
+    }
+
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/StringDiscriminatorConverter.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/StringDiscriminatorConverter.java
@@ -1,0 +1,24 @@
+package org.springframework.data.cassandra.mapping;
+
+import java.util.List;
+
+/**
+ * Created by Lukasz Swiatek on 6/13/16.
+ */
+public class StringDiscriminatorConverter implements DiscriminatorConverter<String> {
+    public static final StringDiscriminatorConverter IT = new StringDiscriminatorConverter();
+    @Override
+    public List<String> getAllValues() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String convert(String discriminator) {
+        return discriminator;
+    }
+
+    @Override
+    public String fromString(String tableName) {
+        return tableName;
+    }
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/TableDiscriminator.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/TableDiscriminator.java
@@ -1,0 +1,14 @@
+package org.springframework.data.cassandra.mapping;
+
+import java.lang.annotation.*;
+
+/**
+ * Created by Lukasz Swiatek on 6/8/16.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+public @interface TableDiscriminator {
+    String[] value() default {};
+    Class<? extends DiscriminatorConverter>[] converter() default {};
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/AbstractCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/AbstractCassandraQuery.java
@@ -130,6 +130,10 @@ public abstract class AbstractCassandraQuery implements RepositoryQuery {
 		Class<?> declaredReturnType = method.getReturnType().getType();
 		Class<?> returnedUnwrappedObjectType = method.getReturnedObjectType();
 
+		if (method.isVoidQuery()){
+			return null;
+		}
+
 		if (method.isSingleEntityQuery()) {
 			return getSingleEntity(resultSet, returnedUnwrappedObjectType);
 		}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/StringBasedCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/StringBasedCassandraQuery.java
@@ -11,6 +11,7 @@ import org.springframework.data.cassandra.core.CassandraOperations;
 public class StringBasedCassandraQuery extends AbstractCassandraQuery {
 
 	private static final Pattern PLACEHOLDER = Pattern.compile("\\?(\\d+)");
+	private static final Pattern TABLE_PLACEHOLDER = Pattern.compile("@table\\b");
 	private static final Logger LOG = LoggerFactory.getLogger(StringBasedCassandraQuery.class);
 
 	protected String query;
@@ -32,10 +33,15 @@ public class StringBasedCassandraQuery extends AbstractCassandraQuery {
 	}
 
 	private String replacePlaceholders(String input, CassandraParameterAccessor accessor, CassandraConverter converter) {
+		String result = input;
+		Matcher tableMatcher = TABLE_PLACEHOLDER.matcher(input);
+		if (tableMatcher.find()){
+			String group = tableMatcher.group();
+			String replacement = getQueryMethod().resolveTableName(accessor);
+			result=result.replace(group, replacement);
+		}
 
 		Matcher matcher = PLACEHOLDER.matcher(input);
-		String result = input;
-
 		while (matcher.find()) {
 			String group = matcher.group();
 			int index = Integer.parseInt(matcher.group(1));

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/support/SimpleCassandraRepository.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/support/SimpleCassandraRepository.java
@@ -76,7 +76,7 @@ public class SimpleCassandraRepository<T, ID extends Serializable> implements Ty
 
 	@Override
 	public long count() {
-		return operations.count(entityInformation.getTableName());
+		return operations.count(entityInformation.getJavaType());
 	}
 
 	@Override
@@ -96,7 +96,7 @@ public class SimpleCassandraRepository<T, ID extends Serializable> implements Ty
 
 	@Override
 	public void deleteAll() {
-		operations.truncate(entityInformation.getTableName());
+		operations.deleteAll(entityInformation.getJavaType());
 	}
 
 	@Override

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/composites/Notification.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/composites/Notification.java
@@ -17,8 +17,8 @@ package org.springframework.data.cassandra.test.integration.composites;
 
 import java.util.Date;
 
-import org.springframework.data.annotation.Id;
 import org.springframework.data.cassandra.mapping.Indexed;
+import org.springframework.data.cassandra.mapping.PrimaryKey;
 import org.springframework.data.cassandra.mapping.Table;
 
 /**
@@ -34,7 +34,7 @@ public class Notification {
 	/*
 	 * Primary Key
 	 */
-	@Id
+	@PrimaryKey
 	private NotificationPK pk;
 
 	@Indexed

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/composites/Post.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/composites/Post.java
@@ -19,7 +19,7 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Set;
 
-import org.springframework.data.annotation.Id;
+import org.springframework.data.cassandra.mapping.PrimaryKey;
 import org.springframework.data.cassandra.mapping.Table;
 
 /**
@@ -36,7 +36,7 @@ public class Post {
 	/*
 	 * Primary Key
 	 */
-	@Id
+	@PrimaryKey
 	private PostPK pk;
 
 	private String type; // status, share

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/composites/Timeline.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/composites/Timeline.java
@@ -17,7 +17,7 @@ package org.springframework.data.cassandra.test.integration.composites;
 
 import java.util.Date;
 
-import org.springframework.data.annotation.Id;
+import org.springframework.data.cassandra.mapping.PrimaryKey;
 import org.springframework.data.cassandra.mapping.Table;
 
 /**
@@ -34,7 +34,7 @@ public class Timeline {
 	/*
 	 * Row ID
 	 */
-	@Id
+	@PrimaryKey
 	private TimelinePK pk;
 
 	/*

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/forcequote/compositeprimarykey/ForceQuotedCompositePrimaryKeyRepositoryIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/forcequote/compositeprimarykey/ForceQuotedCompositePrimaryKeyRepositoryIntegrationTests.java
@@ -13,6 +13,7 @@ public class ForceQuotedCompositePrimaryKeyRepositoryIntegrationTests {
 
 	ImplicitRepository i;
 	ExplicitRepository e;
+	MultitableRepository m;
 	CassandraTemplate t;
 
 	public void before() {
@@ -82,5 +83,34 @@ public class ForceQuotedCompositePrimaryKeyRepositoryIntegrationTests {
 		// delete
 		e.delete(key);
 		assertNull(e.findOne(key));
+	}
+
+	public void testMultitable(String tableName, String discriminator, String stringValueColumnName, String keyZeroColumnName,
+							 String keyOneColumnName) {
+		MultitableKey key = new MultitableKey(discriminator, UUID.randomUUID().toString(), UUID.randomUUID().toString());
+		Multitable entity = new Multitable(key);
+
+		// insert
+		Multitable s = m.save(entity);
+		assertSame(s, entity);
+
+		// select
+		Multitable f = m.findOne(key);
+		assertNotSame(f, entity);
+		String stringValue = query(stringValueColumnName, tableName , keyZeroColumnName, f.getPrimaryKey().getKeyZero(),
+				keyOneColumnName, f.getPrimaryKey().getKeyOne());
+		assertEquals(f.getStringValue(), stringValue);
+
+		// update
+		f.setStringValue(f.getStringValue() + "X");
+		Multitable u = m.save(f);
+		assertSame(u, f);
+		f = m.findOne(u.getPrimaryKey());
+		assertNotSame(f, u);
+		assertEquals(u.getStringValue(), f.getStringValue());
+
+		// delete
+		m.delete(key);
+		assertNull(m.findOne(key));
 	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/forcequote/compositeprimarykey/ForceQuotedCompositePrimaryKeyRepositoryIntegrationTestsDelegator.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/forcequote/compositeprimarykey/ForceQuotedCompositePrimaryKeyRepositoryIntegrationTestsDelegator.java
@@ -21,6 +21,9 @@ public abstract class ForceQuotedCompositePrimaryKeyRepositoryIntegrationTestsDe
 	ExplicitRepository e;
 
 	@Autowired
+	MultitableRepository m;
+
+	@Autowired
 	CassandraTemplate t;
 
 	@Before
@@ -29,6 +32,7 @@ public abstract class ForceQuotedCompositePrimaryKeyRepositoryIntegrationTestsDe
 		tests.i = i;
 		tests.e = e;
 		tests.t = t;
+		tests.m = m;
 
 		tests.before();
 	}
@@ -42,5 +46,10 @@ public abstract class ForceQuotedCompositePrimaryKeyRepositoryIntegrationTestsDe
 			String keyOneColumnName) {
 
 		tests.testExplicit(tableName, stringValueColumnName, keyZeroColumnName, keyOneColumnName);
+	}
+
+	public void testMultitable(String tableName, String discriminator, String stringValueColumnName, String keyZeroColumnName,
+							   String keyOneColumnName) {
+		tests.testMultitable(tableName, discriminator, stringValueColumnName, keyZeroColumnName, keyOneColumnName);
 	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/forcequote/compositeprimarykey/ForceQuotedCompositePrimaryKeyRepositoryJavaConfigIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/forcequote/compositeprimarykey/ForceQuotedCompositePrimaryKeyRepositoryJavaConfigIntegrationTests.java
@@ -20,4 +20,17 @@ public class ForceQuotedCompositePrimaryKeyRepositoryJavaConfigIntegrationTests 
 				String.format("\"%s\"", Explicit.STRING_VALUE_COLUMN_NAME),
 				String.format("\"%s\"", ExplicitKey.EXPLICIT_KEY_ZERO), String.format("\"%s\"", ExplicitKey.EXPLICIT_KEY_ONE));
 	}
+
+	@Test
+	public void testMultitable1() {
+		testMultitable("Table1");
+		testMultitable("Table2");
+	}
+
+	private void testMultitable(String table1) {
+		testMultitable(String.format("\"%s_%s\"", Multitable.TABLE_NAME, table1),
+				table1,
+				String.format("\"%s\"", Multitable.STRING_VALUE_COLUMN_NAME),
+				String.format("\"%s\"", MultitableKey.MULTITABLE_KEY_ZERO), String.format("\"%s\"", MultitableKey.MULTITABLE_KEY_ONE));
+	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/forcequote/compositeprimarykey/Multitable.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/forcequote/compositeprimarykey/Multitable.java
@@ -1,0 +1,50 @@
+package org.springframework.data.cassandra.test.integration.forcequote.compositeprimarykey;
+
+import java.util.UUID;
+
+import org.springframework.data.cassandra.mapping.Column;
+import org.springframework.data.cassandra.mapping.PrimaryKey;
+import org.springframework.data.cassandra.mapping.Table;
+
+/**
+ * Created by Lukasz Swiatek on 6/15/16.
+ */
+@Table(forceQuote = true, value = Multitable.TABLE_NAME + "_@discriminator")
+public class Multitable {
+    public static final String TABLE_NAME = "JavaMultitableTable";
+    public static final String STRING_VALUE_COLUMN_NAME = "JavaMultitableStringValue";
+
+    @PrimaryKey
+    MultitableKey primaryKey;
+    @Column(value = STRING_VALUE_COLUMN_NAME, forceQuote = true)
+    String stringValue = UUID.randomUUID().toString();
+
+
+    public Multitable() {
+    }
+
+    public Multitable(MultitableKey primaryKey) {
+        this.primaryKey = primaryKey;
+    }
+
+    public Multitable(MultitableKey primaryKey, String stringValue) {
+        this.primaryKey = primaryKey;
+        this.stringValue = stringValue;
+    }
+
+    public String getStringValue() {
+        return stringValue;
+    }
+
+    public MultitableKey getPrimaryKey() {
+        return primaryKey;
+    }
+
+    public void setPrimaryKey(MultitableKey primaryKey) {
+        this.primaryKey = primaryKey;
+    }
+
+    public void setStringValue(String stringValue) {
+        this.stringValue = stringValue;
+    }
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/forcequote/compositeprimarykey/MultitableKey.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/forcequote/compositeprimarykey/MultitableKey.java
@@ -1,0 +1,57 @@
+package org.springframework.data.cassandra.test.integration.forcequote.compositeprimarykey;
+
+import java.io.Serializable;
+
+import org.springframework.cassandra.core.PrimaryKeyType;
+import org.springframework.data.cassandra.mapping.PrimaryKeyClass;
+import org.springframework.data.cassandra.mapping.PrimaryKeyColumn;
+import org.springframework.data.cassandra.mapping.TableDiscriminator;
+
+/**
+ * Created by Lukasz Swiatek on 6/15/16.
+ */
+@PrimaryKeyClass
+public class MultitableKey implements Serializable{
+    public static final String MULTITABLE_KEY_ZERO = "JavaMultitableKeyZero";
+    public static final String MULTITABLE_KEY_ONE = "JavaMultitableKeyOne";
+    public static final String MULTITABLE_DISCRIMINATOR = "JavaMultitableDiscriminator";
+
+    @PrimaryKeyColumn(ordinal = 2, forceQuote = true, name = MULTITABLE_DISCRIMINATOR)
+    @TableDiscriminator({"Table1", "Table2"})
+    String discriminator;
+    @PrimaryKeyColumn(ordinal = 0, type = PrimaryKeyType.PARTITIONED, forceQuote = true, name = MULTITABLE_KEY_ZERO)
+    String keyZero;
+
+    @PrimaryKeyColumn(ordinal = 1, forceQuote = true, name = MULTITABLE_KEY_ONE)
+    String keyOne;
+
+    public MultitableKey(String discriminator, String keyZero, String keyOne) {
+        this.discriminator = discriminator;
+        this.keyZero = keyZero;
+        this.keyOne = keyOne;
+    }
+
+    public String getDiscriminator() {
+        return discriminator;
+    }
+
+    public void setDiscriminator(String discriminator) {
+        this.discriminator = discriminator;
+    }
+
+    public String getKeyZero() {
+        return keyZero;
+    }
+
+    public void setKeyZero(String keyZero) {
+        this.keyZero = keyZero;
+    }
+
+    public String getKeyOne() {
+        return keyOne;
+    }
+
+    public void setKeyOne(String keyOne) {
+        this.keyOne = keyOne;
+    }
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/forcequote/compositeprimarykey/MultitableRepository.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/forcequote/compositeprimarykey/MultitableRepository.java
@@ -1,0 +1,9 @@
+package org.springframework.data.cassandra.test.integration.forcequote.compositeprimarykey;
+
+import org.springframework.data.cassandra.repository.TypedIdCassandraRepository;
+
+/**
+ * Created by Lukasz Swiatek on 6/15/16.
+ */
+public interface MultitableRepository extends TypedIdCassandraRepository<Multitable, MultitableKey>{
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/mapping/BasicCassandraPersistentEntityVerifierIntegrationTest.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/mapping/BasicCassandraPersistentEntityVerifierIntegrationTest.java
@@ -47,10 +47,11 @@ public class BasicCassandraPersistentEntityVerifierIntegrationTest {
 
 	}
 
-	@Test(expected = MappingException.class)
+	@Test
 	public void testNonPersistentType() {
 
-		mappingContext.getPersistentEntity(NonPersistentClass.class);
+		CassandraPersistentEntity<?> persistentEntity = mappingContext.getPersistentEntity(NonPersistentClass.class);
+		assertNull(persistentEntity);
 
 	}
 

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/mapping/CassandraCompositePrimaryKeyIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/mapping/CassandraCompositePrimaryKeyIntegrationTests.java
@@ -141,8 +141,9 @@ public class CassandraCompositePrimaryKeyIntegrationTests {
 			actualColumnNames.addAll(p.getColumnNames());
 		}
 		assertTrue(expectedColumnNames.equals(actualColumnNames));
-
-		CreateTableSpecification spec = context.getCreateTableSpecificationFor(thing);
+        List<CreateTableSpecification> specs = context.getCreateTableSpecificationFor(thing);
+		assertEquals(1, specs.size());
+		CreateTableSpecification spec = specs.get(0);
 
 		List<ColumnSpecification> partitionKeyColumns = spec.getPartitionKeyColumns();
 		assertEquals(1, partitionKeyColumns.size());

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/mapping/DiscriminableCassandraPersistentEntityIntegrationTest.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/mapping/DiscriminableCassandraPersistentEntityIntegrationTest.java
@@ -1,0 +1,121 @@
+package org.springframework.data.cassandra.test.integration.mapping;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.Serializable;
+import java.util.HashSet;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cassandra.core.PrimaryKeyType;
+import org.springframework.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.mapping.*;
+import org.springframework.data.mapping.model.MappingException;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.google.common.collect.Sets;
+
+/**
+ * Created by Lukasz Swiatek on 6/13/16.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class DiscriminableCassandraPersistentEntityIntegrationTest {
+
+    @Table("T_@discriminator")
+    public static class Complex {
+        @PrimaryKeyClass
+        public static class ComplexKey implements Serializable{
+            @TableDiscriminator(value = {"A", "B"}, converter = StringDiscriminatorConverter.class)
+            String discriminator;
+            @PrimaryKeyColumn(type = PrimaryKeyType.PARTITIONED, ordinal = 0)
+            String key;
+
+        }
+
+        @PrimaryKey
+        ComplexKey key;
+    }
+    @Table("T_@discriminator_magic")
+    public static class Complex2 {
+        @PrimaryKeyClass
+        public static class ComplexKey implements Serializable{
+            @TableDiscriminator({"A", "B"})
+            String discriminator;
+            @PrimaryKeyColumn(type = PrimaryKeyType.PARTITIONED, ordinal = 0)
+            String key;
+
+        }
+
+        @PrimaryKey
+        ComplexKey key;
+    }
+
+    @Autowired
+    BasicCassandraMappingContext ctx;
+
+    @Test
+    public void testMultitableEntityTableNames(){
+        CassandraPersistentEntity<?> persistentEntity = ctx.getPersistentEntity(Complex.class);
+        HashSet<String> names = Sets.newHashSet("t_a", "t_b");
+        for (CqlIdentifier cqlIdentifier : persistentEntity.getEntityDiscriminator().getTableNames()) {
+            assertTrue(names.remove(cqlIdentifier.toCql()));
+        }
+        assertEquals(0 , names.size());
+
+    }
+
+    @Test
+    public void testTableNamesWithPattern(){
+        CassandraPersistentEntity<?> persistentEntity = ctx.getPersistentEntity(Complex2.class);
+        HashSet<String> names = Sets.newHashSet("t_a_magic", "t_b_magic");
+        for (CqlIdentifier cqlIdentifier : persistentEntity.getEntityDiscriminator().getTableNames()) {
+            assertTrue(names.remove(cqlIdentifier.toCql()));
+        }
+        assertEquals(0 , names.size());
+    }
+
+    @Test
+    public void testParseTableNameWithPattern(){
+        CassandraPersistentEntity<?> persistentEntity = ctx.getPersistentEntity(Complex2.class);
+        Object a = persistentEntity.getEntityDiscriminator().parseTableName("t_a_magic");
+        assertEquals("a", a);
+
+        Object b = persistentEntity.getEntityDiscriminator().parseTableName("t_b_magic");
+        assertEquals("b", b);
+    }
+
+
+    @Test
+    public void testResolveName(){
+        CassandraPersistentEntity<Complex> persistentEntity = (CassandraPersistentEntity<Complex>) ctx.getPersistentEntity(Complex.class);
+        Complex type = new Complex();
+        type.key = new Complex.ComplexKey();
+        type.key.discriminator = "B";
+        CqlIdentifier cqlIdentifier = persistentEntity.getEntityDiscriminator().getTableNameFor(type);
+        assertEquals("t_b", cqlIdentifier.toCql());
+    }
+
+    @Test
+    public void testResolveNameById(){
+        CassandraPersistentEntity<?> persistentEntity = ctx.getPersistentEntity(Complex.class);
+
+        Complex.ComplexKey key = new Complex.ComplexKey();
+        key.discriminator = "B";
+        CqlIdentifier cqlIdentifier = persistentEntity.getEntityDiscriminator().getTableNameForId(key);
+        assertEquals("t_b", cqlIdentifier.toCql());
+    }
+
+    @Test(expected = MappingException.class)
+    public void testResolveUnknown(){
+        CassandraPersistentEntity<Complex> persistentEntity = (CassandraPersistentEntity<Complex>) ctx.getPersistentEntity(Complex.class);
+        Complex type = new Complex();
+        type.key = new Complex.ComplexKey();
+        type.key.discriminator = "C";
+        persistentEntity.getEntityDiscriminator().getTableNameFor(type);
+    }
+
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/mapping/DiscriminableEnumCassandraPersistentEntityIntegrationTest.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/mapping/DiscriminableEnumCassandraPersistentEntityIntegrationTest.java
@@ -1,0 +1,109 @@
+package org.springframework.data.cassandra.test.integration.mapping;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.Serializable;
+import java.util.HashSet;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cassandra.core.PrimaryKeyType;
+import org.springframework.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.mapping.*;
+import org.springframework.data.cassandra.test.integration.support.AbstractSpringDataEmbeddedCassandraIntegrationTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.google.common.collect.Sets;
+
+/**
+ * Created by Lukasz Swiatek on 6/13/16.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class DiscriminableEnumCassandraPersistentEntityIntegrationTest extends AbstractSpringDataEmbeddedCassandraIntegrationTest {
+
+    public enum Discriminator {
+        D1,
+        D2,
+        D3
+    }
+
+
+    @Table("T1_@discriminator")
+    public static class Complex {
+        @PrimaryKeyClass
+        public static class ComplexKey implements Serializable {
+            @TableDiscriminator
+            Discriminator discriminator;
+            @PrimaryKeyColumn(type = PrimaryKeyType.PARTITIONED, ordinal = 0)
+            String key;
+
+        }
+
+        @PrimaryKey
+        ComplexKey key;
+    }
+
+    @Table("T2_@discriminator_magic")
+    public static class Complex2 {
+        @PrimaryKeyClass
+        public static class ComplexKey implements Serializable {
+            @TableDiscriminator
+            Discriminator discriminator;
+            @PrimaryKeyColumn(type = PrimaryKeyType.PARTITIONED, ordinal = 0)
+            String key;
+
+        }
+
+        @PrimaryKey
+        ComplexKey key;
+    }
+
+    @Autowired
+    BasicCassandraMappingContext ctx;
+
+    @Test
+    public void testMultitableEntityTableNames() {
+        CassandraPersistentEntity<?> persistentEntity = ctx.getPersistentEntity(Complex.class);
+        HashSet<String> names = Sets.newHashSet("t1_d1", "t1_d2", "t1_d3");
+        for (CqlIdentifier cqlIdentifier : persistentEntity.getEntityDiscriminator().getTableNames()) {
+            assertTrue(names.remove(cqlIdentifier.toCql()));
+        }
+        assertEquals(0, names.size());
+
+    }
+
+    @Test
+    public void testTableNamesWithPattern() {
+        CassandraPersistentEntity<?> persistentEntity = ctx.getPersistentEntity(Complex2.class);
+        HashSet<String> names = Sets.newHashSet("t2_d1_magic", "t2_d2_magic", "t2_d3_magic");
+        for (CqlIdentifier cqlIdentifier : persistentEntity.getEntityDiscriminator().getTableNames()) {
+            assertTrue(names.remove(cqlIdentifier.toCql()));
+        }
+        assertEquals(0, names.size());
+    }
+
+    @Test
+    public void testResolveName() {
+        CassandraPersistentEntity<Complex> persistentEntity = (CassandraPersistentEntity<Complex>) ctx.getPersistentEntity(Complex.class);
+        Complex type = new Complex();
+        type.key = new Complex.ComplexKey();
+        type.key.discriminator = Discriminator.D2;
+        CqlIdentifier cqlIdentifier = persistentEntity.getEntityDiscriminator().getTableNameFor(type);
+        assertEquals("t1_d2", cqlIdentifier.toCql());
+    }
+
+    @Test
+    public void testResolveNameById() {
+        CassandraPersistentEntity<?> persistentEntity = ctx.getPersistentEntity(Complex.class);
+
+        Complex.ComplexKey key = new Complex.ComplexKey();
+        key.discriminator = Discriminator.D2;
+        CqlIdentifier cqlIdentifier = persistentEntity.getEntityDiscriminator().getTableNameForId(key);
+        assertEquals("t1_d2", cqlIdentifier.toCql());
+    }
+
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/mapping/TableOptionsIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/mapping/TableOptionsIntegrationTests.java
@@ -7,6 +7,7 @@ import org.springframework.cassandra.core.keyspace.CreateTableSpecification;
 import org.springframework.data.cassandra.mapping.*;
 import org.springframework.data.util.ClassTypeInformation;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
@@ -30,7 +31,9 @@ public class TableOptionsIntegrationTests {
 
     @Test
     public void validateTableOptions() {
-        CreateTableSpecification tableSpec = context.getCreateTableSpecificationFor(entity);
+        List<CreateTableSpecification> specs = context.getCreateTableSpecificationFor(entity);
+        assertEquals(1, specs.size());
+        CreateTableSpecification tableSpec = specs.get(0);
         assertEquals(
                 "Table comment not present in CreateTableSpecification",
                 "'" + Entity.class.getAnnotation(Table.class).comment() + "'",

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/querymethods/multitable/MultiTableIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/querymethods/multitable/MultiTableIntegrationTests.java
@@ -1,0 +1,84 @@
+package org.springframework.data.cassandra.test.integration.querymethods.multitable;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.cassandra.config.SchemaAction;
+import org.springframework.data.cassandra.repository.config.EnableCassandraRepositories;
+import org.springframework.data.cassandra.test.integration.support.AbstractSpringDataEmbeddedCassandraIntegrationTest;
+import org.springframework.data.cassandra.test.integration.support.IntegrationTestConfig;
+import org.springframework.data.mapping.model.MappingException;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class MultiTableIntegrationTests extends AbstractSpringDataEmbeddedCassandraIntegrationTest {
+
+    private Thing e1;
+    private Thing e2;
+
+    @Configuration
+    @EnableCassandraRepositories(basePackageClasses = org.springframework.data.cassandra.test.integration.querymethods.multitable.ThingRepo.class)
+    public static class Config extends IntegrationTestConfig {
+        @Override
+        public String[] getEntityBasePackages() {
+            return new String[]{Thing.class.getPackage().getName()};
+        }
+
+        @Override
+        public SchemaAction getSchemaAction() {
+            return SchemaAction.RECREATE_DROP_UNUSED;
+        }
+    }
+
+    @Autowired
+    ThingRepo repo;
+
+    @Before
+    public void sutUp() {
+        e1 = new Thing();
+        e1.pk = new Thing.ThingKey();
+        e1.pk.discriminator = "A";
+        e1.pk.key = "keyA";
+        e1.value = 11;
+        e2 = new Thing();
+        e2.pk = new Thing.ThingKey();
+        e2.pk.discriminator = "B";
+        e2.pk.key = "keyB";
+        e2.value = 22;
+        repo.deleteAll();
+        repo.save(e1);
+        repo.save(e2);
+    }
+
+    @Test
+    public void testSimpleQuery() {
+        Thing thing = repo.findThing("A", "keyA");
+
+        assertNotNull(thing);
+        assertEquals(e1.pk.discriminator, thing.pk.discriminator);
+        assertEquals(e1.pk.key, thing.pk.key);
+        assertEquals(e1.value, thing.value);
+    }
+
+    @Test(expected = MappingException.class)
+    public void testInvalidDiscrimiantor() {
+        Thing thing = repo.findThing("C", "keyA");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullDiscriminator() {
+        Thing thing = repo.findThing(null, "keyA");
+    }
+
+    @Test
+    public void testNotFound() {
+        Thing thing = repo.findThing("B", "keyA");
+        assertNull(thing);
+    }
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/querymethods/multitable/Thing.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/querymethods/multitable/Thing.java
@@ -1,0 +1,64 @@
+package org.springframework.data.cassandra.test.integration.querymethods.multitable;
+
+import java.io.Serializable;
+
+import org.springframework.cassandra.core.PrimaryKeyType;
+import org.springframework.data.cassandra.mapping.*;
+
+/**
+ * Created by Lukasz Swiatek on 6/14/16.
+ */
+@Table("thing_@discriminator")
+public class Thing {
+    @PrimaryKeyClass
+    public static class ThingKey implements Serializable{
+        @PrimaryKeyColumn(ordinal = 0, type = PrimaryKeyType.PARTITIONED)
+        @TableDiscriminator({"A","B"})
+        String discriminator;
+
+        @PrimaryKeyColumn(ordinal = 1, type = PrimaryKeyType.PARTITIONED)
+        String key;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            ThingKey thingKey = (ThingKey) o;
+
+            if (discriminator != null ? !discriminator.equals(thingKey.discriminator) : thingKey.discriminator != null)
+                return false;
+            return key != null ? key.equals(thingKey.key) : thingKey.key == null;
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = discriminator != null ? discriminator.hashCode() : 0;
+            result = 31 * result + (key != null ? key.hashCode() : 0);
+            return result;
+        }
+    }
+    @PrimaryKey
+    ThingKey pk;
+    Integer value;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Thing thing = (Thing) o;
+
+        if (pk != null ? !pk.equals(thing.pk) : thing.pk != null) return false;
+        return value != null ? value.equals(thing.value) : thing.value == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = pk != null ? pk.hashCode() : 0;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        return result;
+    }
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/querymethods/multitable/ThingRepo.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/querymethods/multitable/ThingRepo.java
@@ -1,0 +1,13 @@
+package org.springframework.data.cassandra.test.integration.querymethods.multitable;
+
+import org.springframework.data.cassandra.mapping.TableDiscriminator;
+import org.springframework.data.cassandra.repository.Query;
+import org.springframework.data.cassandra.repository.TypedIdCassandraRepository;
+
+/**
+ * Created by Lukasz Swiatek on 6/14/16.
+ */
+public interface ThingRepo extends TypedIdCassandraRepository<Thing, Thing.ThingKey> {
+    @Query("select * from @table where discriminator=?0 and key=?1")
+    Thing findThing(@TableDiscriminator String discriminator, String key);
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/multitable/DiscEntity.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/multitable/DiscEntity.java
@@ -1,0 +1,60 @@
+package org.springframework.data.cassandra.test.integration.repository.multitable;
+
+import java.io.Serializable;
+
+import org.springframework.cassandra.core.PrimaryKeyType;
+import org.springframework.data.cassandra.mapping.*;
+
+/**
+ * Created by Lukasz Swiatek on 6/13/16.
+ */
+@Table("entity_@discriminator")
+public class DiscEntity {
+    @PrimaryKeyClass
+    public static class DiscEntityKey implements Serializable {
+        @TableDiscriminator(value = {"A", "B"}, converter = StringDiscriminatorConverter.class)
+        String discriminator;
+        @PrimaryKeyColumn(ordinal = 0, type = PrimaryKeyType.PARTITIONED)
+        String key;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            DiscEntityKey that = (DiscEntityKey) o;
+
+            if (discriminator != null ? !discriminator.equals(that.discriminator) : that.discriminator != null)
+                return false;
+            return key != null ? key.equals(that.key) : that.key == null;
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = discriminator != null ? discriminator.hashCode() : 0;
+            result = 31 * result + (key != null ? key.hashCode() : 0);
+            return result;
+        }
+    }
+
+    @PrimaryKey
+    DiscEntityKey key;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DiscEntity that = (DiscEntity) o;
+
+        return key != null ? key.equals(that.key) : that.key == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return key != null ? key.hashCode() : 0;
+    }
+}
+

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/multitable/DiscEntityRepository.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/multitable/DiscEntityRepository.java
@@ -1,0 +1,9 @@
+package org.springframework.data.cassandra.test.integration.repository.multitable;
+
+import org.springframework.data.cassandra.repository.TypedIdCassandraRepository;
+
+/**
+ * Created by Lukasz Swiatek on 6/13/16.
+ */
+public interface DiscEntityRepository extends TypedIdCassandraRepository<DiscEntity,DiscEntity.DiscEntityKey> {
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/multitable/MultitableRepositoryIntegrationTest.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/multitable/MultitableRepositoryIntegrationTest.java
@@ -1,0 +1,185 @@
+package org.springframework.data.cassandra.test.integration.repository.multitable;
+
+import static org.junit.Assert.*;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.cassandra.core.CassandraOperations;
+import org.springframework.data.cassandra.test.integration.support.AbstractSpringDataEmbeddedCassandraIntegrationTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+/**
+ * Created by Lukasz Swiatek on 6/13/16.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class MultitableRepositoryIntegrationTest extends AbstractSpringDataEmbeddedCassandraIntegrationTest {
+    @Autowired
+    DiscEntityRepository repo;
+    @Autowired
+    protected CassandraOperations template;
+
+    private DiscEntity ent1;
+    private DiscEntity ent2;
+    private DiscEntity ent3;
+    private DiscEntity ent4;
+
+    @Before
+    public void setUp() {
+        LinkedList<Object> entities = new LinkedList<Object>();
+        ent1 = new DiscEntity();
+        ent1.key = new DiscEntity.DiscEntityKey();
+        ent1.key.discriminator = "A";
+        ent1.key.key = "key1";
+
+        ent2 = new DiscEntity();
+        ent2.key = new DiscEntity.DiscEntityKey();
+        ent2.key.discriminator = "A";
+        ent2.key.key = "key2";
+
+        ent3 = new DiscEntity();
+        ent3.key = new DiscEntity.DiscEntityKey();
+        ent3.key.discriminator = "B";
+        ent3.key.key = "key3";
+
+        ent4 = new DiscEntity();
+        ent4.key = new DiscEntity.DiscEntityKey();
+        ent4.key.discriminator = "A";
+        ent4.key.key = "key4";
+
+        entities.add(ent1);
+        entities.add(ent2);
+        entities.add(ent3);
+        entities.add(ent4);
+        template.deleteAll(DiscEntity.class);
+        template.insert(entities);
+    }
+
+    @Test
+    public void testSave() {
+        DiscEntity entity = new DiscEntity();
+        entity.key = new DiscEntity.DiscEntityKey();
+        entity.key.discriminator = "A";
+        entity.key.key = "new";
+
+        repo.save(entity);
+
+        DiscEntity discEntity = template.selectOneById(DiscEntity.class, entity.key);
+        assertNotNull(discEntity);
+
+    }
+
+    @Test
+    public void testDelete() {
+        repo.delete(ent2);
+
+        DiscEntity discEntity = template.selectOneById(DiscEntity.class, ent2.key);
+        assertNull(discEntity);
+    }
+
+    @Test
+    public void testDeleteById() {
+        repo.delete(ent2.key);
+
+        DiscEntity discEntity = template.selectOneById(DiscEntity.class, ent2.key);
+        assertNull(discEntity);
+    }
+
+    @Test
+    public void testDeleteAll() {
+        repo.deleteAll();
+        long count = template.count(DiscEntity.class);
+        assertEquals(0, count);
+    }
+
+    @Test
+    public void testFind() {
+        DiscEntity one = repo.findOne(ent3.key);
+        assertNotNull(one);
+        assertEquals(ent3, one);
+
+    }
+
+    @Test
+    public void testFindAll() {
+        Iterable<DiscEntity> all = repo.findAll();
+        assertEquals(4, Iterables.size(all));
+        HashSet<DiscEntity> ents = Sets.newHashSet(ent1, ent2, ent3, ent4);
+        ents.removeAll(Lists.newArrayList(all));
+        assertEquals(0, ents.size());
+    }
+
+    //right now cassandraTemplate does not support selectByComplexId
+    @Test(expected = IllegalArgumentException.class)
+    public void testFindAllById() {
+        Iterable<DiscEntity> all = repo.findAll(Lists.newArrayList(ent1.key, ent3.key));
+        assertEquals(2, Iterables.size(all));
+        HashSet<DiscEntity> ents = Sets.newHashSet(ent1, ent3);
+        ents.removeAll(Lists.newArrayList(all));
+        assertEquals(0, ents.size());
+    }
+
+    @Test
+    public void testCount() {
+        long count = repo.count();
+        assertEquals(4, count);
+    }
+
+    @Test
+    public void testExists() {
+        boolean exists = repo.exists(ent4.key);
+        assertEquals(true, exists);
+
+    }
+
+    @Test
+    public void testNotExists() {
+        DiscEntity.DiscEntityKey id = new DiscEntity.DiscEntityKey();
+        id.discriminator = "A";
+        id.key = "notExists";
+        boolean exists = repo.exists(id);
+        assertEquals(false, exists);
+    }
+
+    @Test
+    public void testBachSave() {
+        DiscEntity e1 = new DiscEntity();
+        e1.key = new DiscEntity.DiscEntityKey();
+        e1.key.discriminator = "A";
+        e1.key.key = "new1";
+        DiscEntity e2 = new DiscEntity();
+        e2.key = new DiscEntity.DiscEntityKey();
+        e2.key.discriminator = "B";
+        e2.key.key = "new2";
+        repo.save(Lists.newArrayList(e1, e2));
+
+        long count = template.count(DiscEntity.class);
+        assertEquals(6, count);
+    }
+
+    @Test
+    public void testBachDelete() {
+        repo.delete(Lists.newArrayList(ent2, ent3));
+        long count = template.count(DiscEntity.class);
+        assertEquals(2, count);
+    }
+
+    @Test
+    public void testSavesInProperTable() {
+        Long aCount = template.queryForObject(QueryBuilder.select().countAll().from("entity_A"), Long.class);
+        Long bCount = template.queryForObject(QueryBuilder.select().countAll().from("entity_B"), Long.class);
+        assertEquals(3, (long)aCount);
+        assertEquals(1, (long)bCount);
+    }
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/support/IntegrationTestConfig.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/support/IntegrationTestConfig.java
@@ -22,9 +22,12 @@ import java.util.List;
 
 import org.springframework.cassandra.core.keyspace.CreateKeyspaceSpecification;
 import org.springframework.cassandra.test.unit.support.Utils;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.data.cassandra.config.SchemaAction;
 import org.springframework.data.cassandra.config.java.AbstractCassandraConfiguration;
+import org.springframework.data.cassandra.test.integration.repository.ConversionServiceFactoryBean;
 
 /**
  * Setup any spring configuration for unit tests
@@ -60,4 +63,15 @@ public class IntegrationTestConfig extends AbstractCassandraConfiguration {
 	protected List<CreateKeyspaceSpecification> getKeyspaceCreations() {
 		return Arrays.asList(createKeyspace().name(getKeyspaceName()).withSimpleReplication());
 	}
+
+	@Bean
+	@Override
+	public ConversionService conversionService(){
+		try {
+			return new ConversionServiceFactoryBean().getObject();
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/unit/BasicCassandraPersistentEntityOrderPropertiesTest.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/unit/BasicCassandraPersistentEntityOrderPropertiesTest.java
@@ -69,30 +69,6 @@ public class BasicCassandraPersistentEntityOrderPropertiesTest {
 
 	}
 
-	@Test
-	public void testTablePropertyOrder() {
-
-		CassandraPersistentEntity<?> entity = mappingContext.getPersistentEntity(CompositeKeyEntity.class);
-
-		expected = new LinkedList<CassandraPersistentProperty>();
-		expected.add(entity.getPersistentProperty("key"));
-		expected.add(entity.getPersistentProperty("attribute"));
-		expected.add(entity.getPersistentProperty("text"));
-
-		final List<CassandraPersistentProperty> actual = new LinkedList<CassandraPersistentProperty>();
-
-		entity.doWithProperties(new PropertyHandler<CassandraPersistentProperty>() {
-
-			@Override
-			public void doWithPersistentProperty(CassandraPersistentProperty persistentProperty) {
-				actual.add(persistentProperty);
-			}
-		});
-
-		assertEquals(expected, actual);
-
-	}
-
 	@Table
 	static class CompositeKeyEntity {
 

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/test/integration/config/CassandraNamespaceTests-context.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/test/integration/config/CassandraNamespaceTests-context.xml
@@ -26,10 +26,6 @@
 			durable-writes="true" />
 	</cass:cluster>
 
-	<!-- TODO: not require that these beans be defined -->
-	<cass:mapping />
-	<cass:converter />
-
 	<cass:session keyspace-name="${cassandra.keyspace}"
 		schema-action="NONE" />
 

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/test/integration/mapping/DiscriminableCassandraPersistentEntityIntegrationTest-context.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/test/integration/mapping/DiscriminableCassandraPersistentEntityIntegrationTest-context.xml
@@ -4,19 +4,18 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="
 		http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+		http://www.springframework.org/schema/cassandra http://www.springframework.org/schema/cassandra/spring-cassandra-1.0.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
-	<bean name="randomKeyspaceName" class="java.lang.String">
-		<constructor-arg value="#{'ks' + T(java.util.UUID).randomUUID().toString().replaceAll('-', '')}"/>
-	</bean>
-	
 	<context:property-placeholder
-		location="classpath:/spring-data-cassandra-build.properties" />
+			location="classpath:/spring-data-cassandra-build.properties" />
 
-	<bean id="conversionService" class="org.springframework.data.cassandra.test.integration.repository.ConversionServiceFactoryBean"/>
-	<cass:converter conversion-service-ref="conversionService" mapping-ref="cassandraMapping"/>
+	<cass:cluster port="${cassandra.native_transport_port}" />
 
-	<cass:template />
+	<cass:session keyspace-name="system" />
 
+	<cass:repositories
+			base-package="org.springframework.data.cassandra.test.integration.mapping" />
+	<bean class="org.springframework.data.cassandra.mapping.StringDiscriminatorConverter" lazy-init="false"/>
 </beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/test/integration/mapping/DiscriminableEnumCassandraPersistentEntityIntegrationTest-context.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/test/integration/mapping/DiscriminableEnumCassandraPersistentEntityIntegrationTest-context.xml
@@ -4,19 +4,18 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="
 		http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+		http://www.springframework.org/schema/cassandra http://www.springframework.org/schema/cassandra/spring-cassandra-1.0.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
-	<bean name="randomKeyspaceName" class="java.lang.String">
-		<constructor-arg value="#{'ks' + T(java.util.UUID).randomUUID().toString().replaceAll('-', '')}"/>
-	</bean>
-	
 	<context:property-placeholder
-		location="classpath:/spring-data-cassandra-build.properties" />
+			location="classpath:/spring-data-cassandra-build.properties" />
 
-	<bean id="conversionService" class="org.springframework.data.cassandra.test.integration.repository.ConversionServiceFactoryBean"/>
-	<cass:converter conversion-service-ref="conversionService" mapping-ref="cassandraMapping"/>
+	<cass:cluster port="${cassandra.native_transport_port}" />
 
-	<cass:template />
+	<cass:session keyspace-name="system" />
 
+	<cass:repositories
+			base-package="org.springframework.data.cassandra.test.integration.mapping" />
+	<bean class="org.springframework.data.cassandra.mapping.StringDiscriminatorConverter" lazy-init="false"/>
 </beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/test/integration/repository/multitable/MultitableRepositoryIntegrationTest-context.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/test/integration/repository/multitable/MultitableRepositoryIntegrationTest-context.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cass="http://www.springframework.org/schema/data/cassandra"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="
+		http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.0.xsd
+		">
+
+	<import resource="classpath:/spring-data-cassandra-basic.xml" />
+	<bean class="org.springframework.data.cassandra.mapping.StringDiscriminatorConverter" lazy-init="false"/>
+	<cass:mapping
+		entity-base-packages="org.springframework.data.cassandra.test.integration.repository.multitable">
+		<cass:entity
+			class="org.springframework.data.cassandra.test.integration.repository.multitable.DiscEntity">
+			<cass:table name="entity" />
+		</cass:entity>
+	</cass:mapping>
+	
+	<cass:converter/>
+
+	<cass:cluster port="${cassandra.native_transport_port}">
+		<cass:keyspace name="#{randomKeyspaceName}"
+			action="CREATE" durable-writes="true">
+		</cass:keyspace>
+	</cass:cluster>
+
+	<cass:session keyspace-name="#{randomKeyspaceName}"
+		schema-action="CREATE">
+	</cass:session>
+
+	<cass:repositories
+		base-package="org.springframework.data.cassandra.test.integration.repository.multitable" />
+
+
+	<bean name="randomKeyspaceName" class="java.lang.String">
+		<constructor-arg value="#{'ks' + T(java.util.UUID).randomUUID().toString().replaceAll('-', '')}"/>
+	</bean>
+
+	<context:property-placeholder
+			location="classpath:/spring-data-cassandra-build.properties" />
+</beans>


### PR DESCRIPTION
this functionality allows to specify table name pattern and table discriminator for any given entity
such entity will created multiple tables with the same columns and options, and during save
each entity will be saved into one of those tables based on discriminator value. Also when selecting entity
it will be taken from table based on discriminator value (which is a part of key).