### PR TITLE
support for in-clause in queries

### DIFF
--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/querymethods/inclause/InClauseIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/querymethods/inclause/InClauseIntegrationTests.java
@@ -1,0 +1,91 @@
+package org.springframework.data.cassandra.test.integration.querymethods.inclause;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.cassandra.config.SchemaAction;
+import org.springframework.data.cassandra.repository.config.EnableCassandraRepositories;
+import org.springframework.data.cassandra.test.integration.support.AbstractSpringDataEmbeddedCassandraIntegrationTest;
+import org.springframework.data.cassandra.test.integration.support.IntegrationTestConfig;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by Tomek Adamczewski on 25/07/16.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class InClauseIntegrationTests extends AbstractSpringDataEmbeddedCassandraIntegrationTest {
+
+    @Configuration
+    @EnableCassandraRepositories(basePackageClasses = TestModel.class)
+    public static class Config extends IntegrationTestConfig {
+        @Override
+        public String[] getEntityBasePackages() {
+            return new String[]{TestModel.class.getPackage().getName()};
+        }
+
+        @Override
+        public SchemaAction getSchemaAction() {
+            return SchemaAction.RECREATE_DROP_UNUSED;
+        }
+    }
+
+    @Autowired
+    TestRepo repo;
+
+    @Before
+    public void setUp() {
+        cleanupTable();
+        createEntity("type1", "1", "value11");
+        createEntity("type1", "2", "value12");
+        createEntity("type2", "1", "value21");
+        createEntity("type3", "", "value3");
+    }
+
+    @Test
+    public void test() {
+        // type 3 and no values
+        assertTrue(repo.findModelsByTypeAndVersionsIn("type1", list()).isEmpty());
+
+        // type 3 and multiple invalid values
+        assertTrue(repo.findModelsByTypeAndVersionsIn("type3", list("1", "2")).isEmpty());
+
+        // type 1 and multiple valid values
+        assertEquals(2, repo.findModelsByTypeAndVersionsIn("type1", list("1", "2")).size());
+
+        // type 2 and multiple (one valid, one not) values
+        assertEquals(1, repo.findModelsByTypeAndVersionsIn("type2", list("1", "2")).size());
+
+        // type 3 and no values
+        assertTrue(repo.findModelsByTypeAndVersionsIn("type3", list()).isEmpty());
+
+        // type 3 and valid (empty) value
+        assertEquals(1, repo.findModelsByTypeAndVersionsIn("type3", list("")).size());
+    }
+
+    private List<String> list(String... values) {
+        return Arrays.asList(values);
+    }
+
+    private void createEntity(String type, String version, String value) {
+        TestModel e1 = new TestModel();
+        e1.key = new TestModel.PK();
+        e1.key.type = type;
+        e1.key.version = version;
+        e1.value = value;
+        repo.save(e1);
+    }
+
+    private void cleanupTable() {
+        repo.deleteAll();
+    }
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/querymethods/inclause/TestModel.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/querymethods/inclause/TestModel.java
@@ -1,0 +1,67 @@
+package org.springframework.data.cassandra.test.integration.querymethods.inclause;
+
+import org.springframework.data.annotation.AccessType;
+import org.springframework.data.cassandra.mapping.*;
+
+import java.io.Serializable;
+
+import static com.datastax.driver.core.DataType.Name.TEXT;
+import static org.springframework.cassandra.core.PrimaryKeyType.CLUSTERED;
+import static org.springframework.cassandra.core.PrimaryKeyType.PARTITIONED;
+
+/**
+ * Created by Tomek Adamczewski on 25/07/16.
+ */
+@Table("models")
+public class TestModel {
+
+    @AccessType(AccessType.Type.PROPERTY)
+    @PrimaryKeyClass
+    public static class PK implements Serializable {
+
+        @PrimaryKeyColumn(ordinal = 0, type= PARTITIONED)
+        @CassandraType(type = TEXT)
+        String type;
+
+        @PrimaryKeyColumn(ordinal = 1, type = CLUSTERED)
+        @CassandraType(type = TEXT)
+        String version;
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public void setVersion(String version) {
+            this.version = version;
+        }
+    }
+
+    @PrimaryKey
+    PK key;
+
+    String value;
+
+    public PK getKey() {
+        return key;
+    }
+
+    public void setKey(PK key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/querymethods/inclause/TestRepo.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/querymethods/inclause/TestRepo.java
@@ -1,0 +1,19 @@
+package org.springframework.data.cassandra.test.integration.querymethods.inclause;
+
+import org.springframework.data.cassandra.mapping.CassandraType;
+import org.springframework.data.cassandra.repository.Query;
+import org.springframework.data.cassandra.repository.TypedIdCassandraRepository;
+
+import java.util.List;
+
+import static com.datastax.driver.core.DataType.Name.LIST;
+import static com.datastax.driver.core.DataType.Name.TEXT;
+
+/**
+ * Created by Tomek Adamczewski on 25/07/16.
+ */
+public interface TestRepo extends TypedIdCassandraRepository<TestModel, TestModel.PK> {
+
+    @Query("select * from models where type = ?0 and version in (?1) allow filtering")
+    List<TestModel> findModelsByTypeAndVersionsIn(String type, @CassandraType(type= LIST, typeArguments = TEXT) List<String> versions);
+}


### PR DESCRIPTION
You can now use "select * from X when y in (?)" with lists, arrays or collections of attributes