### PR TITLE
Fix for issue of spring-data-cassandra not accepting factory-produced beans (lazy initialised)

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/BeanDefinitionUtils.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/BeanDefinitionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors
+ * Copyright 2013-2016 the original author or authors
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,15 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.util.StringUtils;
 
+/**
+ * Utilities to lookup {@link BeanDefinition bean definitions} for a {@link ListableBeanFactory} and to conditionally
+ * register {@link BeanDefinition bean definitions}.
+ *
+ * @author Matthew Adams
+ * @author Mark Paluch
+ * @deprecated Will be removed with the next major release.
+ */
+@Deprecated
 public class BeanDefinitionUtils {
 
 	/**

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraMappingBeanFactoryPostProcessor.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraMappingBeanFactoryPostProcessor.java
@@ -161,16 +161,16 @@ public class CassandraMappingBeanFactoryPostProcessor implements BeanFactoryPost
 		return contextBean;
 	}
 
-	private BeanDefinitionHolder registerDefaultConverter(BeanDefinitionRegistry registry, String contextBeanName) {
+	public BeanDefinitionHolder registerDefaultConverter(BeanDefinitionRegistry registry, String contextBeanName, String cnvServiceBeanName) {
 
-		BeanDefinition beanDefinition = BeanDefinitionBuilder //
-				.genericBeanDefinition(MappingCassandraConverter.class) //
-				.addConstructorArgReference(contextBeanName).getBeanDefinition();
+		BeanDefinitionBuilder converterBeanDefinitionBuilder = BeanDefinitionBuilder.genericBeanDefinition(
+				MappingCassandraConverter.class).addConstructorArgReference(cnvServiceBeanName).addConstructorArgReference(contextBeanName);
+		BeanDefinitionHolder beanDefinition = new BeanDefinitionHolder(converterBeanDefinitionBuilder.getBeanDefinition(),
+				DefaultBeanNames.CONVERTER);
 
-		BeanDefinitionHolder converter = new BeanDefinitionHolder(beanDefinition, DefaultBeanNames.CONVERTER);
-		registry.registerBeanDefinition(converter.getBeanName(), converter.getBeanDefinition());
+		registry.registerBeanDefinition(beanDefinition.getBeanName(), beanDefinition.getBeanDefinition());
 
-		return converter;
+		return beanDefinition;
 	}
 
 	private BeanDefinitionHolder registerDefaultTemplate(BeanDefinitionRegistry registry, String sessionBeanName,

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraMappingBeanFactoryPostProcessor.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraMappingBeanFactoryPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors
+ * Copyright 2013-2016 the original author or authors
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,34 +15,38 @@
  */
 package org.springframework.data.cassandra.config;
 
-import static org.springframework.data.cassandra.config.BeanDefinitionUtils.getBeanDefinitionsOfType;
+import static org.springframework.data.cassandra.config.BeanDefinitionUtils.*;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.data.cassandra.convert.CassandraConverter;
 import org.springframework.data.cassandra.convert.MappingCassandraConverter;
 import org.springframework.data.cassandra.core.CassandraOperations;
 import org.springframework.data.cassandra.core.CassandraTemplate;
-import org.springframework.data.cassandra.mapping.CassandraMappingContext;
 import org.springframework.data.cassandra.mapping.BasicCassandraMappingContext;
+import org.springframework.data.cassandra.mapping.CassandraMappingContext;
 import org.springframework.util.StringUtils;
 
 import com.datastax.driver.core.Session;
 
 /**
- * {@link BeanDefinitionRegistryPostProcessor} that does its best to register any missing Spring Data Cassandra beans
- * that can be defaulted. Specifically, it attempts to create default bean definitions for the following required
- * interface types via their default implementation types:
+ * {@link BeanFactoryPostProcessor} that does its best to register any missing Spring Data Cassandra beans that can be
+ * defaulted. Specifically, it attempts to create default bean definitions for the following required interface types
+ * via their default implementation types:
  * <ul>
  * <li>{@link CassandraOperations} via {@link CassandraTemplate}</li>
  * <li>{@link CassandraMappingContext} via {@link BasicCassandraMappingContext}</li>
- * <li> {@link CassandraConverter} via {@link MappingCassandraConverter}</li>
+ * <li>{@link CassandraConverter} via {@link MappingCassandraConverter}</li>
  * </ul>
  * <p/>
  * If there are multiple definitions for any type that another type depends on, an {@link IllegalStateException} is
@@ -57,59 +61,53 @@ import com.datastax.driver.core.Session;
  * It requires that a single {@link Session} or {@link CassandraSessionFactoryBean} definition be present. As described
  * above, multiple {@link Session} definitions, multiple {@link CassandraSessionFactoryBean} definitions, or both a
  * {@link Session} and {@link CassandraSessionFactoryBean} will cause an {@link IllegalStateException} to be thrown.
- * 
+ *
  * @author Matthew T. Adams
+ * @author Mark Paluch
+ * @deprecated Will be removed with the next major release. Spring Data Cassandra is not the best place to apply
+ *             configuration defaults.
  */
-public class CassandraMappingBeanFactoryPostProcessor implements BeanDefinitionRegistryPostProcessor {
-
-	/**
-	 * Does nothing.
-	 */
-	@Override
-	public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {}
+@Deprecated
+public class CassandraMappingBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
 
 	/**
 	 * Ensures that {@link BeanDefinition}s for a {@link CassandraMappingContext} and a {@link CassandraConverter} exist.
 	 */
 	@Override
-	public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+	public void postProcessBeanFactory(ConfigurableListableBeanFactory factory) throws BeansException {
 
-		if (!(registry instanceof ListableBeanFactory)) {
+		if (!(factory instanceof BeanDefinitionRegistry)) {
 			return;
 		}
-		ListableBeanFactory factory = (ListableBeanFactory) registry;
 
-		registerMissingDefaultableBeanDefinitions(registry, factory);
+		registerMissingDefaultableBeanDefinitions((BeanDefinitionRegistry) factory, factory);
 	}
 
-	protected void registerMissingDefaultableBeanDefinitions(BeanDefinitionRegistry registry, ListableBeanFactory factory) {
+	private void registerMissingDefaultableBeanDefinitions(BeanDefinitionRegistry registry, ListableBeanFactory factory) {
 
 		// see if any template definitions exist, which requires a converter, which requires a mapping context
 		BeanDefinitionHolder[] templateBeans = getBeanDefinitionsOfType(registry, factory, CassandraOperations.class, true,
-				false);
+				true);
 
 		if (templateBeans.length >= 1) {
 			return;
 		}
 
 		// need a session & converter for the default template
-
 		// see if an actual Session definition exists
 		String sessionBeanName = findSessionBeanName(registry, factory);
 
 		// see if any converter bean definitions exist, which requires a mapping context
-		BeanDefinitionHolder[] converterBeans = getBeanDefinitionsOfType(registry, factory,
-				MappingCassandraConverter.class, true, false);
+		BeanDefinitionHolder[] converterBeans = getBeanDefinitionsOfType(registry, factory, MappingCassandraConverter.class,
+				true, false);
+
+		if (converterBeans.length > 1) {
+			throw createAmbiguousBeansException(converterBeans.length, CassandraConverter.class, CassandraTemplate.class);
+		}
 
 		if (converterBeans.length == 1) {
-
 			registerDefaultTemplate(registry, sessionBeanName, converterBeans[0].getBeanName());
 			return;
-		} else if (converterBeans.length > 1) {
-			// then throw, because we need to create a default converter, but we wouldn't know which mapping context to use
-			throw new IllegalStateException(String.format(
-					"found %d beans of type [%s] - can't disambiguate for creation of [%s]", converterBeans.length,
-					CassandraConverter.class.getName(), CassandraTemplate.class.getName()));
 		}
 
 		// see if any mapping context bean definitions exist
@@ -118,84 +116,85 @@ public class CassandraMappingBeanFactoryPostProcessor implements BeanDefinitionR
 
 		if (contextBeans.length > 1) {
 			// then throw, because we need to create a default converter, but we wouldn't know which mapping context to use
-			throw new IllegalStateException(String.format(
-					"found %d beans of type [%s] - can't disambiguate for creation of [%s]", contextBeans.length,
-					CassandraMappingContext.class.getName(), MappingCassandraConverter.class.getName()));
+			throw createAmbiguousBeansException(contextBeans.length, MappingCassandraConverter.class,
+					CassandraMappingContext.class);
 		}
 
 		// create the mapping context if necessary
-		BeanDefinitionHolder contextBean = contextBeans.length == 1 ? contextBeans[0] : null;
-		if (contextBean == null) {
-			contextBean = regsiterDefaultContext(registry);
-		}
+		BeanDefinitionHolder contextBean = contextBeans.length == 1 ? contextBeans[0] : registerDefaultContext(registry);
 
 		// create the default converter & template bean definitions
 		BeanDefinitionHolder converter = registerDefaultConverter(registry, contextBean.getBeanName(), "conversionService");
 		registerDefaultTemplate(registry, sessionBeanName, converter.getBeanName());
 	}
 
-	public String findSessionBeanName(BeanDefinitionRegistry registry, ListableBeanFactory factory) {
+	private String findSessionBeanName(BeanDefinitionRegistry registry, ListableBeanFactory factory) {
 
 		// first, search for any session and session factory beans
-		BeanDefinitionHolder[] sessionBeans = getBeanDefinitionsOfType(registry, factory, Session.class, true, false);
-		BeanDefinitionHolder[] sessionFactoryBeans = getBeanDefinitionsOfType(registry, factory,
-				CassandraSessionFactoryBean.class, true, false);
+		BeanDefinitionHolder[] sessionBeans = getBeanDefinitionsOfType(registry, factory, Session.class, true, true);
 
-		int sessionCount = sessionBeans.length;
-		int sessionFactoryCount = sessionFactoryBeans.length;
-		int totalCount = sessionCount + sessionFactoryCount;
-
-		if (totalCount == 0 || totalCount > 1) { // can't create default template -- none or multiple
-			throw createSessionException(totalCount, Session.class, CassandraSessionFactoryBean.class);
-		}
-
-		if (sessionCount == 1) {
+		if (sessionBeans.length == 1) { // can't create default template -- none or multiple
 			return sessionBeans[0].getBeanName();
 		}
-		// else it must be the one session factory bean
-		return sessionFactoryBeans[0].getBeanName();
+
+		throw createAmbiguousBeansException(sessionBeans.length, CassandraTemplate.class, Session.class,
+				CassandraSessionFactoryBean.class);
 	}
 
-	protected IllegalStateException createSessionException(int beanDefinitionCount, Class<?>... types) {
+	private IllegalStateException createAmbiguousBeansException(int beanDefinitionCount, Class<?> defaultBeanType,
+			Class<?>... types) {
 
-		return new IllegalStateException(String.format("found %d beans of type%s [%s] - %s for creation of default [%s]",
-				beanDefinitionCount, beanDefinitionCount == 1 ? "" : "s", StringUtils.arrayToCommaDelimitedString(types),
-				beanDefinitionCount == 0 ? "need exactly one" : "can't disambiguate", CassandraTemplate.class.getName()));
+		return new IllegalStateException(
+				String.format("found %d beans of type%s [%s] - %s for creation of default [%s]", beanDefinitionCount,
+						beanDefinitionCount == 1 ? "" : "s", StringUtils.collectionToCommaDelimitedString(getNames(types)),
+						beanDefinitionCount == 0 ? "need exactly one" : "can't disambiguate", defaultBeanType.getName()));
 	}
 
-	protected BeanDefinitionHolder regsiterDefaultContext(BeanDefinitionRegistry registry) {
+	private BeanDefinitionHolder registerDefaultContext(BeanDefinitionRegistry registry) {
 
-		BeanDefinitionHolder contextBean = new BeanDefinitionHolder(BeanDefinitionBuilder.genericBeanDefinition(
-				BasicCassandraMappingContext.class).getBeanDefinition(), DefaultBeanNames.CONTEXT);
+		BeanDefinitionHolder contextBean = new BeanDefinitionHolder(
+				BeanDefinitionBuilder.genericBeanDefinition(BasicCassandraMappingContext.class).getBeanDefinition(),
+				DefaultBeanNames.CONTEXT);
 
 		registry.registerBeanDefinition(contextBean.getBeanName(), contextBean.getBeanDefinition());
 
 		return contextBean;
 	}
 
-	public BeanDefinitionHolder registerDefaultConverter(BeanDefinitionRegistry registry, String contextBeanName, String cnvServiceBeanName) {
+	private BeanDefinitionHolder registerDefaultConverter(BeanDefinitionRegistry registry, String contextBeanName) {
 
-		BeanDefinitionBuilder converterBeanDefinitionBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-				MappingCassandraConverter.class).addConstructorArgReference(cnvServiceBeanName).addConstructorArgReference(contextBeanName);
-		BeanDefinitionHolder beanDefinition = new BeanDefinitionHolder(converterBeanDefinitionBuilder.getBeanDefinition(),
-				DefaultBeanNames.CONVERTER);
+		BeanDefinition beanDefinition = BeanDefinitionBuilder //
+				.genericBeanDefinition(MappingCassandraConverter.class) //
+				.addConstructorArgReference(contextBeanName).getBeanDefinition();
 
-		registry.registerBeanDefinition(beanDefinition.getBeanName(), beanDefinition.getBeanDefinition());
+		BeanDefinitionHolder converter = new BeanDefinitionHolder(beanDefinition, DefaultBeanNames.CONVERTER);
+		registry.registerBeanDefinition(converter.getBeanName(), converter.getBeanDefinition());
 
-		return beanDefinition;
+		return converter;
 	}
 
-	public BeanDefinitionHolder registerDefaultTemplate(BeanDefinitionRegistry registry, String sessionBeanName,
+	private BeanDefinitionHolder registerDefaultTemplate(BeanDefinitionRegistry registry, String sessionBeanName,
 			String converterBeanName) {
 
-		BeanDefinitionBuilder templateBeanDefinitionBuilder = BeanDefinitionBuilder
-				.genericBeanDefinition(CassandraTemplate.class).addConstructorArgReference(sessionBeanName)
-				.addConstructorArgReference(converterBeanName);
-		BeanDefinition beanDefinition = templateBeanDefinitionBuilder.getBeanDefinition();
+		BeanDefinition beanDefinition = BeanDefinitionBuilder.genericBeanDefinition(CassandraTemplate.class) //
+				.addConstructorArgReference(sessionBeanName) //
+				.addConstructorArgReference(converterBeanName) //
+				.getBeanDefinition();
 
 		BeanDefinitionHolder template = new BeanDefinitionHolder(beanDefinition, DefaultBeanNames.TEMPLATE);
 		registry.registerBeanDefinition(template.getBeanName(), template.getBeanDefinition());
 
 		return template;
+	}
+
+	private Collection<String> getNames(Class<?>[] types) {
+
+		List<String> names = new ArrayList<String>();
+
+		for (Class<?> type : types) {
+			names.add(type.getName());
+		}
+
+		return names;
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraTemplateFactoryBean.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraTemplateFactoryBean.java
@@ -42,7 +42,7 @@ public class CassandraTemplateFactoryBean implements FactoryBean<CassandraOperat
 
 	@Override
 	public Class<?> getObjectType() {
-		return CassandraOperations.class;
+		return CassandraTemplate.class;
 	}
 
 	@Override

--- a/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cassandra-1.0.xsd
+++ b/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cassandra-1.0.xsd
@@ -753,6 +753,13 @@ The comma-delimited base packages in which to scan for entities and their mappin
 					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="id" type="xsd:ID" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the mapping; default is "cassandraMapping".
+				]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
 
@@ -783,6 +790,13 @@ The reference to a ConversionService. Will default to 'conversionService'.
 						source="org.springframework.data.cassandra.mapping.CassandraMappingContext"><![CDATA[
 The reference to a CassandraMappingContext. Will default to 'cassandraMapping'.
 					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="id" type="xsd:ID" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the mapping; default is "cassandraConverter".
+				]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
 		</xsd:complexType>

--- a/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cassandra-1.5.xsd
+++ b/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cassandra-1.5.xsd
@@ -1,0 +1,933 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/data/cassandra"
+			xmlns:repository="http://www.springframework.org/schema/data/repository"
+			xmlns:tool="http://www.springframework.org/schema/tool"
+			xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			targetNamespace="http://www.springframework.org/schema/data/cassandra"
+			elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans"
+		schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool"
+		schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd" />
+	<xsd:import namespace="http://www.springframework.org/schema/context"
+		schemaLocation="http://www.springframework.org/schema/context/spring-context.xsd" />
+	<xsd:import namespace="http://www.springframework.org/schema/data/repository"
+		schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository.xsd" />
+
+	<xsd:annotation>
+		<xsd:documentation><![CDATA[
+Defines configuration elements in the XML namespace for Spring Data for Apache Cassandra.
+		]]></xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="cluster" type="clusterType">
+		<xsd:annotation>
+			<xsd:documentation
+				source="org.springframework.cassandra.config.xml.CassandraClusterFactoryBean"><![CDATA[
+Defines a Cassandra cluster.
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="com.datastax.driver.core.Cluster" />
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:element name="session" type="sessionType">
+		<xsd:annotation>
+			<xsd:documentation
+				source="org.springframework.data.cassandra.config.CassandraSessionFactoryBean"><![CDATA[
+Defines a Cassandra session.
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="com.datastax.driver.core.Session" />
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:element name="template" type="templateType">
+		<xsd:annotation>
+			<xsd:documentation
+				source="org.springframework.data.cassandra.config.CassandraTemplateFactoryBean"><![CDATA[
+Defines a CassandraTemplate.
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports
+						type="org.springframework.data.cassandra.CassandraTemplate" />
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:simpleType name="clusterRef" final="union">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="com.datastax.driver.core.Cluster"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string" />
+	</xsd:simpleType>
+
+	<xsd:simpleType name="executorRef" final="union">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="java.util.concurrent.Executor"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string" />
+	</xsd:simpleType>
+
+	<xsd:simpleType name="sessionRef" final="union">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="com.datastax.driver.core.Session" />
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string" />
+	</xsd:simpleType>
+
+	<xsd:complexType name="clusterType">
+		<xsd:sequence>
+			<xsd:element name="local-pooling-options" type="poolingOptionsType" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Local pooling options.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="remote-pooling-options" type="poolingOptionsType" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Remote pooling options.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="socket-options" type="socketOptionsType" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Socket options.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="keyspace" type="keyspaceType" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Provides the ability to define a keyspace.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="startup-cql" type="xsd:string" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Arbitrary CQL script to be executed against the system keyspace during bean initialization.  Multiple elements will be executed in document order.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="shutdown-cql" type="xsd:string" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Arbitrary CQL script to be executed against the system keyspace during bean destruction.  Multiple elements will be executed in document order.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The name of the Cassandra Cluster definition; default is "cassandra-cluster".
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="address-translator-ref" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Configures the address translator to use for the new cluster.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="com.datastax.driver.core.policies.AddressTranslator"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+				<xsd:union memberTypes="xsd:string"/>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="auth-info-provider-ref" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+AuthInfoProvider implementation.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="com.datastax.driver.core.AuthInfoProvider" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+				<xsd:union memberTypes="xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="cluster-builder-configurer-ref" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Sets the ClusterBuilderConfigurer used to apply additional configuration logic
+to the com.datastax.driver.core.Cluster.Builder.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="org.springframework.cassandra.config.ClusterBuilderConfigurer"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+				<xsd:union memberTypes="xsd:string"/>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="cluster-name" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+An optional name for the create cluster.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="compression" type="xsd:string" default="NONE" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The protocol compression option. Default is "NONE".
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="contact-points" type="xsd:string" default="localhost" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The comma separated list of Cassandra servers.  Default is "localhost".
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="heartbeat-interval-seconds" type="xsd:string" default="30" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Pooling option to set the heartbeat interval seconds, after which a message is sent on an idle connection
+to make sure it's still alive. Applies to both local and remote pooling options (see
+com.datastax.driver.core.HostDistance and com.datastax.driver.core.PoolingOptions) for more details.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="host-state-listener-ref" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Custom Host State Listener for the Cassandra Cluster.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="com.datastax.driver.core.Host.StateListener" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+				<xsd:union memberTypes="xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="idle-timeout-seconds" type="xsd:string" default="120" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Pooling option to set the timeout in seconds before an idle connection is removed. Applies to both local and remote
+pooling options (see com.datastax.driver.core.HostDistance and com.datastax.driver.core.PoolingOptions) for more details.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="initialization-executor-ref" type="executorRef" use="optional">
+			<xsd:annotation>
+				<xsd:documentation source="org.springframework.cassandra.config.PoolingOptionsFactoryBean"><![CDATA[
+Pooling option defining a reference to an Executor used to initialize the Cassandra Pool. Applies to both local
+and remote pooling options (see com.datastax.driver.core.HostDistance
+and com.datastax.driver.core.PoolingOptions) for more details.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="jmx-reporting-enabled" type="xsd:string" default="true">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Determine whether or not to enable JMX Reporting.  Defaults to true.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="latency-tracker-ref" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Custom Latency Tracker for the Cassandra Cluster.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="com.datastax.driver.core.LatencyTracker" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+				<xsd:union memberTypes="xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="load-balancing-policy-ref" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+LoadBalancingPolicy implementation.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to
+								type="com.datastax.driver.core.policies.LoadBalancingPolicy" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+				<xsd:union memberTypes="xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="netty-options-ref" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+NettyOptions implementation reference.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to
+								type="com.datastax.driver.core.NettyOptions" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+				<xsd:union memberTypes="xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="max-queue-size" type="xsd:string" default="256" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Sets the maximum number of requests that get enqueued if no connection is available.
+If the queue grows past this value, new requests will be rejected immediately (and the driver will move to the
+next host in the query plan). This limit is per connection pool, not global to the driver.
+See com.datastax.driver.core.PoolingOption for more details. Available since Cassandra Driver 3.1.1.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="max-schema-agreement-wait-seconds" type="xsd:string" default="10" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Sets the maximum time to wait for schema agreement before returning from a DDL query. Defaults to 10 seconds.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="metrics-enabled" type="xsd:string"
+					   default="true">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Determine whether or not to collect metrics.  Defaults to true.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="password" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+When Authentication is enabled, the password to use when connecting to the Cluster.
+				]]>
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="pool-timeout-milliseconds" type="xsd:string" default="5000" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Pooling option to set the timeout in milliseconds when trying to acquire a connection from a host's pool. Applies to
+both local and remote pooling options (see com.datastax.driver.core.HostDistance
+and com.datastax.driver.core.PoolingOptions) for more details.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="port" type="xsd:string" use="optional" default="9042">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The native CQL port to connect to.  Default is 9042.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="reconnection-policy-ref" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+ReconnectionPolicy implementation.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to
+								type="com.datastax.driver.core.policies.ReconnectionPolicy" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+				<xsd:union memberTypes="xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="retry-policy-ref" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+RetryPolicy implementation.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to
+								type="com.datastax.driver.core.policies.RetryPolicy" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+				<xsd:union memberTypes="xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="speculative-execution-policy-ref" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Configures the speculative execution policy to use for the new cluster.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="com.datastax.driver.core.policies.SpeculativeExecutionPolicy"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+				<xsd:union memberTypes="xsd:string"/>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="ssl-enabled" type="xsd:string" default="false">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Determine if SSL is used for Cassandra communication. Defaults to false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ssl-options-ref" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Custom SSL Options. sslEnabled must be true for sslOptions to be used.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="com.datastax.driver.core.SSLOptions" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+				<xsd:union memberTypes="xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="timestamp-generator-ref" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Configures the generator that will produce the client-side timestamp sent with each query.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="com.datastax.driver.core.TimestampGenerator"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+				<xsd:union memberTypes="xsd:string"/>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="username" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+When Authentication is enabled, the username to use when connecting to the Cluster.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="datacenterType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Provides the ability to specify replication factors by data center.
+					]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="name" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The name of the data center.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="replication-factor" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The replication factor for the data center.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="keyspaceType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Provides the ability to define keyspaces.
+					]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="replication" type="replicationType" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Provides the ability to configure the keyspace's replication settings.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="action" use="required" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The keyspace action to take at startup and possibly shutdown.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="durable-writes" type="xsd:string" use="optional" default="false">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Whether or not the keyspace supports durable writes.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="name" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The name of this keyspace.  Required.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="poolingOptionsType">
+		<xsd:attribute name="core-connections" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+For each host, the driver keeps a core amount of connections open at all time.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="max-connections" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+More connections are created up to a configurable maximum number of connections.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="max-simultaneous-requests" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+If the utilisation of connections reaches this configurable threshold, then cassandra creates more connections up to max-connections.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="min-simultaneous-requests" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+If the utilisation of opened connections drops below by this configured threshold, then cassandra drops connections till core-connections.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="replicationType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Provides the ability to configure the keyspace's replication settings.
+					]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="data-center" type="datacenterType" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Provides the ability to specify replication factors by data center.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="class" type="xsd:string" use="optional" default="SimpleStrategy">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The name of the replication class; default is "SIMPLE_STRATEGY".
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="replication-factor" type="xsd:string" use="optional" default="1">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The replication factor; default is 1.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="sessionType">
+		<xsd:sequence>
+			<xsd:element name="startup-cql" type="xsd:string" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Arbitrary CQL script to be executed against the session's keyspace during bean initialization.  Multiple elements will be executed in document order.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="shutdown-cql" type="xsd:string" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Arbitrary CQL script to be executed against the session's keyspace during bean destruction.  Multiple elements will be executed in document order.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The name of the session definition; default is "cassandra-session".
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="cassandra-converter-ref" type="cassandraConverterRef" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The reference to a CassandraConverter; default is "cassandraConverter".
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="cluster-ref" type="clusterRef" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The reference to a Cassandra cluster; default is "cassandra-cluster".
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="keyspace-name" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The name of a Cassandra Keyspace.  No default; for the system keyspace, use the empty string.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="schema-action" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The schema action to perform; default is NONE.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="socketOptionsType">
+		<xsd:attribute name="connect-timeout-millis" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Sets connection timeout for client socket in milliseconds.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="keep-alive" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Sets the SO_KEEPALIVE socket option.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="read-timeout-millis" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Sets read timeout for client socket in milliseconds.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="receive-buffer-size" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Sets the SO_RCVBUF socket option.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="reuse-address" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Sets the SO_REUSEADDR socket option.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="send-buffer-size" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Sets the SO_SNDBUF socket option.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="so-linger" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Sets the SO_LINGER socket option.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="tcp-no-delay" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Sets the SO_TCPNODELAY socket option.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="templateType">
+		<xsd:attribute name="id" type="xsd:ID" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The name of the template; default is "cassandraTemplate".
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="cassandra-converter-ref" type="cassandraConverterRef" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The reference to a CassandraConverter; default is "cassandraConverter".
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="session-ref" type="sessionRef" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The reference to a Cassandra session; default is "cassandra-session".
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<!-- Spring Data Repository and Mapping (Persistence) Schema Elements -->
+
+	<xsd:element name="converter">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Defines a CassandraConverter for getting rich mapping functionality.
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:exports
+					type="org.springframework.data.cassandra.convert.CassandraConverter" />
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="mapping-ref" type="mappingContextRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation
+						source="org.springframework.data.cassandra.mapping.CassandraMappingContext"><![CDATA[
+The reference to a CassandraMappingContext. Will default to 'cassandraMapping'.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="mapping">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Defines a CassandraMappingContext for holding rich entity mapping information.
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:exports
+					type="org.springframework.data.cassandra.mapping.CassandraMappingContext" />
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="entity" type="entityType" minOccurs="0" maxOccurs="unbounded" />
+				<xsd:element name="user-type-resolver" type="userTypeResolverType" minOccurs="0" maxOccurs="1" />
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:ID" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	The name of the mapping context; default is "cassandraMapping".
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="entity-base-packages" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The comma-delimited base packages in which to scan for entities and their mapping information.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="user-type-resolver-ref" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The reference to a UserTypeResolver. UserTypeResolver is required when working with User-defined types.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:exports
+							type="org.springframework.data.cassandra.mapping.UserTypeResolver" />
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="repositories">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="repository:repositories">
+					<xsd:attributeGroup ref="cassandra-repository-attributes" />
+					<xsd:attributeGroup ref="repository:repository-attributes" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:attributeGroup name="cassandra-repository-attributes">
+		<xsd:attribute name="cassandra-template-ref" type="cassandraTemplateRef">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The reference to a CassandraTemplate. Will default to 'cassandraTemplate'.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:simpleType name="cassandraConverterRef" final="union">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.cassandra.convert.CassandraConverter"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="cassandraTemplateRef" final="union">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to
+						type="org.springframework.data.cassandra.core.CassandraTemplate" />
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="mappingContextRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.cassandra.mapping.CassandraMappingContext"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:complexType name="entityType">
+		<xsd:sequence>
+			<xsd:element name="table" type="tableType" minOccurs="0" maxOccurs="1" />
+			<xsd:element name="property" type="propertyType" minOccurs="0" maxOccurs="unbounded" />
+		</xsd:sequence>
+		<xsd:attribute name="class" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Entity class name.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="propertyType">
+		<xsd:attribute name="column-name" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The column-name that the property should be mapped to.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="force-quote" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Whether the column name should be force-quoted.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="name" type="xsd:string" use="required" >
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The name of the property.  Required.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="tableType">
+		<xsd:attribute name="force-quote" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Whether to force-quote the table name.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="name" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Table name override.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="userTypeResolverType">
+		<xsd:attribute name="keyspace-name" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The name of a Cassandra Keyspace.  No default; for the system keyspace, use the empty string.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="cluster-ref" type="clusterRef" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The reference to a Cassandra cluster; default is "cassandra-cluster".
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraMappingBeanFactoryPostProcessorTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraMappingBeanFactoryPostProcessorTests.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.config;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.springframework.context.support.GenericXmlApplicationContext;
+import org.springframework.data.cassandra.convert.CassandraConverter;
+import org.springframework.data.cassandra.core.CassandraOperations;
+import org.springframework.data.cassandra.mapping.CassandraMappingContext;
+
+import com.datastax.driver.core.Session;
+
+/**
+ * Unit tests for {@link CassandraMappingBeanFactoryPostProcessor}.
+ * 
+ * @author Mark Paluch
+ */
+public class CassandraMappingBeanFactoryPostProcessorTests {
+
+	@Rule public final ExpectedException expectedException = ExpectedException.none();
+
+	/**
+	 * @see DATACASS-290
+	 */
+	@Test
+	public void clusterRegistrationTriggersDefaultBeanRegistration() {
+
+		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
+		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "cluster-and-mock-session.xml");
+		context.refresh();
+
+		assertThat(context.getBeanNamesForType(CassandraOperations.class), hasItemInArray("cqlTemplate"));
+		assertThat(context.getBeanNamesForType(CassandraMappingContext.class), hasItemInArray("cassandraMapping"));
+		assertThat(context.getBeanNamesForType(CassandraConverter.class), hasItemInArray("cassandraConverter"));
+	}
+
+	/**
+	 * @see DATACASS-290
+	 */
+	@Test
+	public void MappingAndConverterRegistrationTriggersDefaultBeanRegistration() {
+
+		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
+		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "mock-session-mapping-converter.xml");
+		context.refresh();
+
+		assertThat(context.getBeanNamesForType(CassandraOperations.class), hasItemInArray("cqlTemplate"));
+	}
+
+	/**
+	 * @see DATACASS-290
+	 */
+	@Test
+	public void converterRegistrationFailsDueToMissingCassandraMapping() {
+
+		expectedException.expect(BeanCreationException.class);
+		expectedException.expectMessage(containsString("No bean named 'cassandraMapping'"));
+
+		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
+		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "mock-session-converter.xml");
+		context.refresh();
+	}
+
+	/**
+	 * @see DATACASS-290
+	 */
+	@Test
+	public void defaultBeanRegistrationShouldFailWithMultipleSessions() {
+
+		expectedException.expect(IllegalStateException.class);
+		expectedException.expectMessage(allOf(containsString("found 2 beans of type"), containsString("Session")));
+
+		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
+		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "multiple-sessions.xml");
+		context.refresh();
+	}
+
+	/**
+	 * @see DATACASS-290
+	 */
+	@Test
+	public void defaultBeanRegistrationShouldFailWithMultipleSessionFactories() {
+
+		expectedException.expect(IllegalStateException.class);
+		expectedException.expectMessage(allOf(containsString("found 2 beans of type"), containsString("Session")));
+
+		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
+		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "multiple-session-factories.xml");
+		context.refresh();
+	}
+
+	/**
+	 * @see DATACASS-290
+	 */
+	@Test
+	public void defaultBeanRegistrationShouldFailWithMultipleMappingContexts() {
+
+		expectedException.expect(IllegalStateException.class);
+		expectedException
+				.expectMessage(allOf(containsString("found 2 beans of type"), containsString("CassandraMappingContext")));
+
+		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
+		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "multiple-mapping-contexts.xml");
+		context.refresh();
+	}
+
+	/**
+	 * @see DATACASS-290
+	 */
+	@Test
+	public void defaultBeanRegistrationShouldFailWithMultipleConvertersContexts() {
+
+		expectedException.expect(IllegalStateException.class);
+		expectedException
+				.expectMessage(allOf(containsString("found 2 beans of type"), containsString("CassandraConverter")));
+
+		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
+		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "multiple-converters.xml");
+		context.refresh();
+	}
+
+	/**
+	 * @see DATACASS-290
+	 */
+	@Test
+	public void shouldAllowTwoKeyspaces() {
+
+		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
+		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "two-keyspaces-namespace.xml");
+		context.refresh();
+
+		assertThat(context.getBeanNamesForType(CassandraOperations.class), arrayContaining("c-1", "c-2"));
+		assertThat(context.getBeanNamesForType(CassandraMappingContext.class), arrayContaining("mapping-1", "mapping-2"));
+		assertThat(context.getBeanNamesForType(CassandraConverter.class), arrayContaining("converter-1", "converter-2"));
+	}
+
+	@SuppressWarnings("unused")
+	private static class MockSessionFactory extends AbstractFactoryBean<Session> {
+
+		@Override
+		public Class<?> getObjectType() {
+			return Session.class;
+		}
+
+		@Override
+		protected Session createInstance() {
+			return mock(Session.class);
+		}
+	}
+}

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/cluster-and-mock-session.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/cluster-and-mock-session.xml
@@ -6,6 +6,8 @@
 
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
+	<bean id="conversionService" class="org.springframework.data.cassandra.test.integration.repository.ConversionServiceFactoryBean"/>
+
 	<cass:cluster/>
 	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
 

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/cluster-and-mock-session.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/cluster-and-mock-session.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<cass:cluster/>
+	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+
+</beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-converter.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-converter.xml
@@ -6,6 +6,8 @@
 
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
+	<bean id="conversionService" class="org.springframework.data.cassandra.test.integration.repository.ConversionServiceFactoryBean"/>
+
 	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
 	<cass:converter />
 

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-converter.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-converter.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+	<cass:converter />
+
+</beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-mapping-converter.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-mapping-converter.xml
@@ -6,6 +6,8 @@
 
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
+	<bean id="conversionService" class="org.springframework.data.cassandra.test.integration.repository.ConversionServiceFactoryBean"/>
+
 	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
 	<cass:mapping/>
 	<cass:converter/>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-mapping-converter.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-mapping-converter.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+	<cass:mapping/>
+	<cass:converter/>
+
+</beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-converters.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-converters.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<cass:cluster/>
+
+	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+
+	<cass:mapping/>
+	<cass:converter/>
+
+	<bean class="org.springframework.data.cassandra.convert.MappingCassandraConverter">
+		<constructor-arg index="0" ref="cassandraMapping"/>
+	</bean>
+
+</beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-mapping-contexts.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-mapping-contexts.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<cass:cluster/>
+	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+	<cass:mapping/>
+	<bean class="org.springframework.data.cassandra.mapping.BasicCassandraMappingContext"/>
+
+</beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-session-factories.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-session-factories.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<cass:cluster/>
+	<cass:session id="session-1" keyspace-name="system"/>
+	<cass:session id="session-2" keyspace-name="system"/>
+
+</beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-sessions.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-sessions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<cass:cluster/>
+	<bean id="mockSession1" class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+	<bean id="mockSession2" class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+
+</beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/two-keyspaces-namespace.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/two-keyspaces-namespace.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<cass:cluster/>
+
+	<bean id="keyspace-1"
+		  class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+	<bean id="keyspace-2"
+		  class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+
+	<cass:mapping id="mapping-1"/>
+	<cass:mapping id="mapping-2"/>
+
+	<cass:converter id="converter-1" mapping-ref="mapping-1"/>
+	<cass:converter id="converter-2" mapping-ref="mapping-2"/>
+
+	<cass:template id="c-1" cassandra-converter-ref="converter-1" session-ref="keyspace-1"/>
+	<cass:template id="c-2" cassandra-converter-ref="converter-2" session-ref="keyspace-2"/>
+
+</beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/two-keyspaces-namespace.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/two-keyspaces-namespace.xml
@@ -6,6 +6,7 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<cass:cluster/>
+	<bean id="conversionService" class="org.springframework.data.cassandra.test.integration.repository.ConversionServiceFactoryBean"/>
 
 	<bean id="keyspace-1"
 		  class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>


### PR DESCRIPTION
CassandraTemplate and CassandraSession beans were transparently replaced by fallbacks (in bean postprocesor) when they were lazy-created by factories. That was not an issue (well, it was, but it was impossible to be spotted) as long as default implementations of mentioned services were used.
The fix comes from original spring-projects/spring-data-cassandra and it also provides additional features of support for multiple keyspaces and JU for those functionalities. 