### PR TITLE
Extension point for providing query options on named queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,7 @@
 					<useFile>false</useFile>
 					<includes>
 						<include>**/test/integration/**/*.java</include>
+						<include>**/config/*Tests.java</include>
 					</includes>
 					<excludes>
 						<exclude>**/test/unit/**/*.java</exclude>

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraMappingBeanFactoryPostProcessor.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraMappingBeanFactoryPostProcessor.java
@@ -181,7 +181,7 @@ public class CassandraMappingBeanFactoryPostProcessor implements BeanFactoryPost
 				.addConstructorArgReference(converterBeanName) //
 				.getBeanDefinition();
 
-		BeanDefinitionHolder template = new BeanDefinitionHolder(beanDefinition, DefaultBeanNames.TEMPLATE);
+		BeanDefinitionHolder template = new BeanDefinitionHolder(beanDefinition, DefaultBeanNames.DATA_TEMPLATE);
 		registry.registerBeanDefinition(template.getBeanName(), template.getBeanDefinition());
 
 		return template;

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/xml/CassandraTemplateParser.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/xml/CassandraTemplateParser.java
@@ -42,7 +42,7 @@ public class CassandraTemplateParser extends CassandraCqlTemplateParser {
 			throws BeanDefinitionStoreException {
 
 		String id = super.resolveId(element, definition, parserContext);
-		return StringUtils.hasText(id) ? id : DefaultBeanNames.DATA_TEMPLATE;
+		return StringUtils.hasText(id) && !DefaultBeanNames.TEMPLATE.equals(id) ? id : DefaultBeanNames.DATA_TEMPLATE;
 	}
 
 	@Override

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/config/CassandraRepositoryConfigurationExtension.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/config/CassandraRepositoryConfigurationExtension.java
@@ -60,7 +60,7 @@ public class CassandraRepositoryConfigurationExtension extends RepositoryConfigu
 		Element element = config.getElement();
 
 		ParsingUtils.addOptionalPropertyReference(builder, "cassandraTemplate", element, CASSANDRA_TEMPLATE_REF,
-				DefaultBeanNames.TEMPLATE);
+				DefaultBeanNames.DATA_TEMPLATE);
 	}
 
 	@Override

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/config/EnableCassandraRepositories.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/config/EnableCassandraRepositories.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Target;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.cassandra.config.DefaultBeanNames;
 import org.springframework.data.cassandra.core.CassandraTemplate;
 import org.springframework.data.cassandra.repository.support.CassandraRepositoryFactoryBean;
 import org.springframework.data.repository.config.DefaultRepositoryBaseClass;
@@ -123,7 +124,7 @@ public @interface EnableCassandraRepositories {
 	 * 
 	 * @return
 	 */
-	String cassandraTemplateRef() default "cassandraTemplate";
+	String cassandraTemplateRef() default DefaultBeanNames.DATA_TEMPLATE;
 
 	/**
 	 * Configures whether nested repository-interfaces (e.g. defined as inner classes) should be discovered by the

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/AbstractCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/AbstractCassandraQuery.java
@@ -27,6 +27,7 @@ import java.util.TreeSet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cassandra.core.QueryOptions;
 import org.springframework.cassandra.core.converter.ResultSetToBigDecimalConverter;
 import org.springframework.cassandra.core.converter.ResultSetToBigIntegerConverter;
 import org.springframework.cassandra.core.converter.ResultSetToBooleanConverter;
@@ -120,8 +121,9 @@ public abstract class AbstractCassandraQuery implements RepositoryQuery {
 		CassandraParameterAccessor accessor = new CassandraParametersParameterAccessor(method, parameters);
 		
 		String query = createQuery(accessor, template.getConverter());
+		QueryOptions queryOptions = getQueryOptions();
 
-		ResultSet resultSet = template.query(query);
+		ResultSet resultSet = template.query(query, queryOptions);
 
 		// return raw result set if requested
 		if (method.isResultSetQuery()) {
@@ -162,6 +164,10 @@ public abstract class AbstractCassandraQuery implements RepositoryQuery {
 		// if we get this far, let the configured conversion service try to convert the result set
 		return conversionService.convert(retval, TypeDescriptor.forObject(retval),
 				TypeDescriptor.valueOf(declaredReturnType));
+	}
+
+	public QueryOptions getQueryOptions() {
+		return null;
 	}
 
 	public Object getCollectionOfEntity(ResultSet resultSet, Class<?> declaredReturnType,

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraMappingBeanFactoryPostProcessorTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraMappingBeanFactoryPostProcessorTests.java
@@ -50,9 +50,9 @@ public class CassandraMappingBeanFactoryPostProcessorTests {
 		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "cluster-and-mock-session.xml");
 		context.refresh();
 
-		assertThat(context.getBeanNamesForType(CassandraOperations.class), hasItemInArray("cqlTemplate"));
-		assertThat(context.getBeanNamesForType(CassandraMappingContext.class), hasItemInArray("cassandraMapping"));
-		assertThat(context.getBeanNamesForType(CassandraConverter.class), hasItemInArray("cassandraConverter"));
+		assertThat(context.getBeanNamesForType(CassandraOperations.class), hasItemInArray(DefaultBeanNames.DATA_TEMPLATE));
+		assertThat(context.getBeanNamesForType(CassandraMappingContext.class), hasItemInArray(DefaultBeanNames.CONTEXT));
+		assertThat(context.getBeanNamesForType(CassandraConverter.class), hasItemInArray(DefaultBeanNames.CONVERTER));
 	}
 
 	/**
@@ -65,7 +65,7 @@ public class CassandraMappingBeanFactoryPostProcessorTests {
 		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "mock-session-mapping-converter.xml");
 		context.refresh();
 
-		assertThat(context.getBeanNamesForType(CassandraOperations.class), hasItemInArray("cqlTemplate"));
+		assertThat(context.getBeanNamesForType(CassandraOperations.class), hasItemInArray(DefaultBeanNames.DATA_TEMPLATE));
 	}
 
 	/**


### PR DESCRIPTION
Main goal of this PR is to provide extension point for adding query options on named query execution.
Also, clearing inconsistency of using bean names. Including context configs tests that were skipped by mvn plugins.